### PR TITLE
Add python-multipart

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ httpx==0.24.0
 idna==3.4
 protobuf==4.23.2 
 pydantic==1.10.8 
+python-multipart==0.0.6
 sniffio==1.3.0
 starlette==0.27.0 
 tomli==2.0.1 


### PR DESCRIPTION
Think I forgot to add this to the commit when swapping images or it somehow otherwise got removed - this fixes the API server to use python-multipart