### PR TITLE
Update cgr.dev/chainguard/go Docker tag to v1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.20 as build
+FROM cgr.dev/chainguard/go:1.21 as build
 
 WORKDIR /work
 


### PR DESCRIPTION
This was previously done in https://github.com/defenseunicorns/leapfrogai/pull/105 which surfaced https://github.com/chainguard-images/images/issues/982 as a breaking change between `:1.20`->`:1.21`, which we have since resolved.

I believe it should be safe to upgrade to `:1.21` now. 🙏 