### PR TITLE
Modify dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.20 as build
+FROM cgr.dev/chainguard/go:latest as build
 
 WORKDIR /work
 

--- a/leapfrog-values.yaml
+++ b/leapfrog-values.yaml
@@ -10,7 +10,7 @@ image:
   # down and only change it if you explicitly want to upgrade the Weaviate
   # version.
   
-  tag: 0.2.1
+  tag: 0.3.2
 
 domain: "###ZARF_VAR_DOMAIN###"
 

--- a/leapfrogai/Dockerfile
+++ b/leapfrogai/Dockerfile
@@ -9,7 +9,7 @@ ENV USER='user'
 RUN groupadd -r user && useradd -r -g $USER $USER
 
 
-RUN mkdir -p /home/$USER
+RUN mkdir -p /home/$USER/app
 
 RUN chown -R $USER /home/$USER
 RUN chmod a+rwx -R  /home/$USER

--- a/models/llms/mpt-7b-chat/Dockerfile
+++ b/models/llms/mpt-7b-chat/Dockerfile
@@ -11,7 +11,7 @@ COPY get_model.py get_model.py
 RUN python3 get_model.py
 
 # Move the rest of the python files (most likely place layer cache will be invalidated)
-COPY --chown=user:user *.py .
+COPY --chown=user:user *.py ./
 
 # Publish port
 EXPOSE 50051:50051

--- a/models/llms/stablelm/Dockerfile
+++ b/models/llms/stablelm/Dockerfile
@@ -9,7 +9,7 @@ COPY get_models.py get_models.py
 # # Get model weights and tokenizer
 RUN python3 get_models.py
 
-COPY *.py .
+COPY *.py ./
 
 # Publish port
 EXPOSE 50051:50051


### PR DESCRIPTION
This PR modifies Dockerfiles and updates the leapfrogai image tags to use when building the Zarf package.
- Updates the chainguard image to use the `latest` tag (versioned image tags are no longer supported)
- Update the image tag for leapfrog images
- Update dockerfile for the base image to ensure the `$HOME/app` directory gets created prior to chowing all the directories. (future images will need to be able to use this directory in as non-root user.