### PR TITLE
Adds initial vector db ADR

### DIFF
--- a/docs/adr/0001-vectordb-backend.md
+++ b/docs/adr/0001-vectordb-backend.md
@@ -7,17 +7,13 @@ Contents:
   - [Decision](#decision)
   - [Rationale](#rationale)
   - [Status](#status)
-- [Context](#Context)
+- [Context](#context)
   - [Important Factors](#important-factors)
   - [Options](#options)
   - [Supporting Information](#supporting-information)
   - [Assumptions](#assumptions)
   - [Constraints](#constraints)
   - [Implications](#implications)
-- [Decision](#decision)
-    - [Rationale](#rationale)
-    - [Status](#status)
-    - [Consequences](#consequences)
 
 ## Summary
 

--- a/docs/adr/0001-vectordb-backend.md
+++ b/docs/adr/0001-vectordb-backend.md
@@ -1,0 +1,86 @@
+# 1. VectorDB
+
+Contents:
+
+- [Summary](#summary)
+  - [Issue](#issue)
+  - [Decision](#decision)
+  - [Rationale](#rationale)
+  - [Status](#status)
+- [Context](#Context)
+  - [Important Factors](#important-factors)
+  - [Options](#options)
+  - [Supporting Information](#supporting-information)
+  - [Assumptions](#assumptions)
+  - [Constraints](#constraints)
+  - [Implications](#implications)
+- [Decision](#decision)
+    - [Rationale](#rationale)
+    - [Status](#status)
+    - [Consequences](#consequences)
+
+## Summary
+
+### Issue
+
+We need to support a vector db for retrieval-augmented generation (RAG), there are many options but we need to choose between them. 
+
+### Decision 
+
+TBD
+
+### Rationale 
+TBD
+
+### Status
+Proposed
+
+## Context
+
+### Important Factors
+- OpenSource
+- Performance
+    - Queries per second
+    - Latency
+- RBAC
+- Self-hosted
+- Portability
+- Developer Experience
+- Sharding
+- Licensing/Fees
+
+### Options
+
+- [Pinecone](https://www.pinecone.io/)
+- [Weaviate](https://weaviate.io/)
+- [Milvus](https://milvus.io/) - [GitHub](https://github.com/milvus-io/milvus) - [Architecture](https://milvus.io/docs/architecture_overview.md)
+- [Qdrant](https://qdrant.tech/)
+- [Chroma](https://www.trychroma.com/)
+- [Elasticsearch](https://www.elastic.co/elasticsearch/)
+- [PGvector](https://github.com/pgvector/pgvector)
+
+### Supporting information
+
+#### Benchmarks
+
+- https://benchmark.vectorview.ai/vectordbs.html
+- https://ann-benchmarks.com/index.html#algorithms
+- https://github.com/milvus-io/milvus/discussions/4939
+
+### Indexing
+- https://weaviate.io/blog/ann-algorithms-vamana-vs-hnsw
+- https://thedataquarry.com/posts/vector-db-3/
+
+
+### Assumptions
+
+- Choosing a single vector db is desirable
+- Not bundling the vector db with the app layer is desirable
+
+### Constraints
+
+TBD
+
+### Implications
+
+TBD

--- a/docs/adr/0001-vectordb-backend.md
+++ b/docs/adr/0001-vectordb-backend.md
@@ -29,7 +29,7 @@ TBD
 TBD
 
 ### Status
-Proposed
+Provisional
 
 ## Context
 


### PR DESCRIPTION
Creates a document for #185 to provide a starting point for determining what vector db will be used with LeapfrogAI.

The initial ADR format is a combination of the following, with some tailoring for this specific issue:
* https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md
* https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/examples/css-framework