### PR TITLE
Changes all the references from whisper-1 to whisper

### DIFF
--- a/api/models.toml
+++ b/api/models.toml
@@ -18,15 +18,15 @@ description = "InstructorXL embedding"
 url = 'localhost:50051'
 type = 'gRPC'
 
-[whisper-1]
+[whisper]
 
-[whisper-1.metadata]
+[whisper.metadata]
 owned_by = 'Defense Unicorns'
 permission = []
 description = "OpenAI's Whisper Large v2"
 tasks = ["translate", "transcribe"]
 
-[whisper-1.network]
+[whisper.network]
 url = 'localhost:50052'
 type = 'gRPC'
 

--- a/chart/templates/api/configmap.yaml
+++ b/chart/templates/api/configmap.yaml
@@ -45,13 +45,13 @@ data:
             type = 'gRPC'   
 {{- end -}}
 {{ if .Values.models.whisper.enabled }}
-    [whisper-1]
-        [whisper-1.metadata]
+    [whisper]
+        [whisper.metadata]
             owned_by    = 'Defense Unicorns'
             permission  = []
             description = "OpenAI's Whisper Large v2"
             tasks = ["translate", "transcribe"]
-        [whisper-1.network]
+        [whisper.network]
             url = 'http://whisper:8000'
             type = 'http'     
 {{- end -}}

--- a/models/speech2text/whisper/zarf-config.yaml
+++ b/models/speech2text/whisper/zarf-config.yaml
@@ -2,7 +2,7 @@ package:
   create:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/whisper"
-      version: 0.0.4
+      version: 0.0.5
       name: whisper
     max_package_size: "1000000000"
   deploy:
@@ -15,4 +15,4 @@ package:
       requests_gpu: 0
       name: whisper
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/whisper"
-      version: 0.0.4
+      version: 0.0.5

--- a/models/speech2text/whisper/zarf-config.yaml
+++ b/models/speech2text/whisper/zarf-config.yaml
@@ -2,7 +2,7 @@ package:
   create:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/whisper"
-      version: 0.0.5
+      version: 0.0.6
       name: whisper
     max_package_size: "1000000000"
   deploy:
@@ -15,4 +15,4 @@ package:
       requests_gpu: 0
       name: whisper
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/whisper"
-      version: 0.0.5
+      version: 0.0.6

--- a/models/speech2text/whisper/zarf.yaml
+++ b/models/speech2text/whisper/zarf.yaml
@@ -1,7 +1,7 @@
 kind: ZarfPackageConfig
 metadata:
   name: whisper
-  version: 0.0.4
+  version: 0.0.5
   description: >
     whisper model
 

--- a/weaviate/zarf.yaml
+++ b/weaviate/zarf.yaml
@@ -49,7 +49,7 @@ components:
       - manifests/namespace.yaml
       - manifests/vs.yaml
     repos:
-    - "###ZARF_PKG_VAR_REPO###"
+    - "###ZARF_PKG_TMPL_REPO###"
     images:
     - "semitechnologies/weaviate:1.18.3"
     - "ghcr.io/defenseunicorns/leapfrogai/weaviate:0.0.4"


### PR DESCRIPTION
* This replaces all references from whisper-1 to whisper so that all of the configs are using the same names. The Zarf skeleton was previously referencing "whisper" while the toml files in this repo were referencing "whisper-1" causing them to fail when deployed to a k8s cluster.
* Also replaces deprecated variable `###ZARF_PKG_VAR_REPO###` with `###ZARF_PKG_TMPL_REPO###`