### PR TITLE
Changed Status from Accepted to Pending

### DIFF
--- a/docs/adr/0002-llm-backend.md
+++ b/docs/adr/0002-llm-backend.md
@@ -57,7 +57,7 @@ Initially, the priority for backend support will focus on GPU and concurrent ser
 
 ### Status
 
-Accepted
+Pending (In-Progress)
 
 ## Context
 


### PR DESCRIPTION
Fixing Error: The original commit was intended to represent a work in progress, but the Status was listed as "Accepted" by accident.

This ADR requires additional research and detail to explain the reasoning behind constraints and priorities, and to describe how top competitors where compared to reach a decision.