### PR TITLE
refactor: migrate text-embeddings zarf config to the monorepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,12 @@ build-vllm: local-registry build-wheel
 
 build-text-embeddings: local-registry build-wheel ## Build the text-embeddings container and Zarf package
 	## Download the wheels for the optional 'text-embeddings' dependencies
-	pip download ".[text-embeddings]" -d build
+	pip wheel ".[text-embeddings]" -w build
 
 	## Copy the deps to the package directory
 	-rm packages/text-embeddings/build/*.whl
 	-mkdir packages/text-embeddings/build
 	cp build/*.whl packages/text-embeddings/build/
-	cp build/*.tar.gz packages/text-embeddings/build/
 
 	## Build the image (and tag it for the local registry)
 	docker build -t ghcr.io/defenseunicorns/leapfrogai/text-embeddings:${LOCAL_VERSION} packages/text-embeddings

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,24 @@ build-vllm: local-registry build-wheel
 
 	## Build the Zarf package
 	zarf package create packages/vllm --registry-override=ghcr.io=localhost:5000 --insecure --set IMAGE_VERSION=${LOCAL_VERSION} --confirm
+
+
+build-text-embeddings: local-registry build-wheel ## Build the text-embeddings container and Zarf package
+	## Download the wheels for the optional 'text-embeddings' dependencies
+	pip download ".[text-embeddings]" -d build
+
+	## Copy the deps to the package directory
+	-rm packages/text-embeddings/build/*.whl
+	-mkdir packages/text-embeddings/build
+	cp build/*.whl packages/text-embeddings/build/
+	cp build/*.tar.gz packages/text-embeddings/build/
+
+	## Build the image (and tag it for the local registry)
+	docker build -t ghcr.io/defenseunicorns/leapfrogai/text-embeddings:${LOCAL_VERSION} packages/text-embeddings
+	docker tag ghcr.io/defenseunicorns/leapfrogai/text-embeddings:${LOCAL_VERSION} localhost:5000/defenseunicorns/leapfrogai/text-embeddings:${LOCAL_VERSION}
+
+	## Push the image to the local registry (Zarf is super slow if the image is only in the local daemon)
+	docker push localhost:5000/defenseunicorns/leapfrogai/text-embeddings:${LOCAL_VERSION}
+
+	## Build the Zarf package
+	zarf package create packages/text-embeddings --registry-override=ghcr.io=localhost:5000 --insecure --set IMAGE_VERSION=${LOCAL_VERSION} --confirm

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,24 @@ build-text-embeddings: local-registry build-wheel ## Build the text-embeddings c
 
 	## Build the Zarf package
 	zarf package create packages/text-embeddings --registry-override=ghcr.io=localhost:5000 --insecure --set IMAGE_VERSION=${LOCAL_VERSION} --confirm
+
+
+build-whisper: local-registry build-wheel ## Build the whisper container and zarf package
+	# Download the wheels for the optional 'whisper' dependencies
+	pip download ".[whisper]" -d build
+
+	# Copy the deps to the package directory
+	-rm packages/whisper/build/*.whl
+	-mkdir packages/whisper/build
+	cp build/*.whl packages/whisper/build/
+	cp build/*.tar.gz packages/whisper/build/
+
+	## Build the image (and tag it for the local registry)
+	docker build -t ghcr.io/defenseunicorns/leapfrogai/whisper:${LOCAL_VERSION} packages/whisper
+	docker tag ghcr.io/defenseunicorns/leapfrogai/whisper:${LOCAL_VERSION} localhost:5000/defenseunicorns/leapfrogai/whisper:${LOCAL_VERSION}
+
+	## Push the image to the local registry (Zarf is super slow if the image is only in the local daemon)
+	docker push localhost:5000/defenseunicorns/leapfrogai/whisper:${LOCAL_VERSION}
+
+	## Build the Zarf package
+	zarf package create packages/whisper --registry-override=ghcr.io=localhost:5000 --insecure --set IMAGE_VERSION=${LOCAL_VERSION} --confirm

--- a/packages/text-embeddings/Dockerfile
+++ b/packages/text-embeddings/Dockerfile
@@ -13,9 +13,7 @@ ENV PATH="/leapfrogai/.venv/bin:$PATH"
 # NOTE: We are copying the leapfrog whl to this filename because installing 'optional extras' from 
 #       a wheel requires the absolute path to the wheel file (instead of a wildcard whl)
 COPY build/*.whl build/
-COPY build/*.tar.gz build/
 COPY build/leapfrogai_api*.whl leapfrogai_api-100.100.100-py3-none-any.whl
-RUN pip install build/*.tar.gz --no-deps
 RUN pip install "leapfrogai_api-100.100.100-py3-none-any.whl[text-embeddings]" --no-index --find-links=build/
 
 

--- a/packages/text-embeddings/Dockerfile
+++ b/packages/text-embeddings/Dockerfile
@@ -1,0 +1,43 @@
+ARG ARCH=amd64
+
+# hardened and slim python w/ developer tools image
+FROM ghcr.io/defenseunicorns/leapfrogai/python:3.11-dev-${ARCH} as builder
+
+WORKDIR /leapfrogai
+
+# create virtual environment for light-weight portability and minimal libraries
+RUN python3.11 -m venv .venv
+ENV PATH="/leapfrogai/.venv/bin:$PATH"
+
+# copy and install all python dependencies
+# NOTE: We are copying the leapfrog whl to this filename because installing 'optional extras' from 
+#       a wheel requires the absolute path to the wheel file (instead of a wildcard whl)
+COPY build/*.whl build/
+COPY build/*.tar.gz build/
+COPY build/leapfrogai_api*.whl leapfrogai_api-100.100.100-py3-none-any.whl
+RUN pip install build/*.tar.gz --no-deps
+RUN pip install "leapfrogai_api-100.100.100-py3-none-any.whl[text-embeddings]" --no-index --find-links=build/
+
+
+# download model
+RUN python -m pip install -U huggingface_hub[cli,hf_transfer]
+ARG REPO_ID="hkunlp/instructor-xl"
+ARG REVISION="ce48b213095e647a6c3536364b9fa00daf57f436"
+COPY scripts/model_download.py scripts/model_download.py
+RUN REPO_ID=${REPO_ID} REVISION=${REVISION} python scripts/model_download.py
+
+# hardened and slim python image
+FROM ghcr.io/defenseunicorns/leapfrogai/python:3.11-${ARCH}
+
+ENV PATH="/leapfrogai/.venv/bin:$PATH"
+
+WORKDIR /leapfrogai
+
+COPY --from=builder /leapfrogai/.venv/ /leapfrogai/.venv/
+COPY --from=builder /leapfrogai/.model/ /leapfrogai/.model/
+
+COPY main.py .
+
+EXPOSE 50051:50051
+
+ENTRYPOINT ["python", "-u", "main.py"]

--- a/packages/text-embeddings/README.md
+++ b/packages/text-embeddings/README.md
@@ -1,0 +1,12 @@
+
+
+# LeapfrogAI llama-cpp-python Backend
+
+A LeapfrogAI API-compatible [instructor-xl](https://huggingface.co/hkunlp/instructor-xl) model for creating embeddings across CPU and GPU infrastructures.
+
+
+# Usage
+
+:construction_worker: This documentation is still under construction. :construction_worker:
+
+

--- a/packages/text-embeddings/chart/Chart.yaml
+++ b/packages/text-embeddings/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: leapfrogai-model
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.4.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.4.2"

--- a/packages/text-embeddings/chart/templates/NOTES.txt
+++ b/packages/text-embeddings/chart/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Please enjoy your model! - Defense Unicorns

--- a/packages/text-embeddings/chart/templates/_helpers.tpl
+++ b/packages/text-embeddings/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+app: {{ include "chart.fullname" . }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/packages/text-embeddings/chart/templates/configmap.yaml
+++ b/packages/text-embeddings/chart/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Values.nameOverride }}-configmap"
+  namespace: leapfrogai
+  labels:
+    leapfrogai: sparkle
+data:
+  models.toml: |
+    [[models]]
+        owned_by    = 'Defense Unicorns'
+        backend     = '{{ include "chart.fullname" . }}:50051'
+        type        = 'gRPC'
+        name        = '{{ .Values.nameOverride }}'

--- a/packages/text-embeddings/chart/templates/deployment.yaml
+++ b/packages/text-embeddings/chart/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/text-embeddings/chart/templates/hpa.yaml
+++ b/packages/text-embeddings/chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/packages/text-embeddings/chart/templates/service.yaml
+++ b/packages/text-embeddings/chart/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  annotations:
+    zarf.dev/connect-description: "{{ .Values.nameOverride }} gRPC endpoint."
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    zarf.dev/connect-name: "{{ .Values.nameOverride }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 50051
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/packages/text-embeddings/chart/templates/serviceaccount.yaml
+++ b/packages/text-embeddings/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/packages/text-embeddings/chart/values.yaml
+++ b/packages/text-embeddings/chart/values.yaml
@@ -1,0 +1,66 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: "ghcr.io/defenseunicorns/leapfrogai/text-embeddings"
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 0.0.1 #TODO: Validate this package version exists
+
+imagePullSecrets: []
+nameOverride: text-embeddings 
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+
+securityContext:
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+
+service:
+  type: ClusterIP
+  port: 50051
+
+gpuEnabled: false 
+
+resources: 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 0
+    memory: 0
+    nvidia.com/gpu: 0
+  requests:
+    cpu: 0
+    memory: 0
+    nvidia.com/gpu: 0
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/packages/text-embeddings/embedding-values.yaml
+++ b/packages/text-embeddings/embedding-values.yaml
@@ -1,0 +1,11 @@
+image:
+  tag: "###ZARF_CONST_IMAGE_VERSION###"
+
+
+# NOTE: This is not a typo, the request and limit values NEED to be the same
+# TODO @JPERRY: Is there a better way to name this variable to make that more clear without needing to read the above comment?
+resources:
+  requests:
+    nvidia.com/gpu: "###ZARF_VAR_REQUESTS_GPU###"
+  limits:
+    nvidia.com/gpu: "###ZARF_VAR_REQUESTS_GPU###"

--- a/packages/text-embeddings/main.py
+++ b/packages/text-embeddings/main.py
@@ -1,0 +1,26 @@
+import asyncio
+import logging
+
+from InstructorEmbedding import INSTRUCTOR
+from leapfrogai_api.types import (
+    Embedding,
+    EmbeddingRequest,
+    EmbeddingResponse,
+    GrpcContext,
+    serve,
+)
+
+model = INSTRUCTOR("./.model")
+
+
+class InstructorEmbedding:
+    async def CreateEmbedding(self, request: EmbeddingRequest, context: GrpcContext):
+        embeddings = model.encode(request.inputs)
+
+        embeddings = [Embedding(embedding=inner_list) for inner_list in embeddings]
+        return EmbeddingResponse(embeddings=embeddings)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(serve(InstructorEmbedding()))

--- a/packages/text-embeddings/scripts/model_download.py
+++ b/packages/text-embeddings/scripts/model_download.py
@@ -1,0 +1,15 @@
+import os
+
+from huggingface_hub import snapshot_download
+
+REPO_ID = os.environ.get("REPO_ID", "hkunlp/instructor-xl")
+REVISION = os.environ.get("REVISION", "ce48b213095e647a6c3536364b9fa00daf57f436")
+
+os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
+snapshot_download(
+    repo_id=REPO_ID,
+    local_dir=".model",
+    local_dir_use_symlinks=False,
+    revision=REVISION,
+)

--- a/packages/text-embeddings/zarf.yaml
+++ b/packages/text-embeddings/zarf.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: text-embeddings
+  version: 0.0.1
+  description: >
+    text embeddings model
+
+constants:
+  - name: IMAGE_VERSION
+    value: "###ZARF_PKG_TMPL_IMAGE_VERSION###"
+
+variables:
+  - name: REQUESTS_GPU
+    description: Use GPU for inferencing. 
+    default: "0"
+    pattern: "^[0-9]+$"
+  
+components:
+  - name: text-embeddings-model
+    required: true
+    charts:
+      - name: text-embeddings-model
+        namespace: leapfrogai
+        localPath: chart
+        releaseName: text-embeddings-model
+        version: 0.0.1 #TODO: Validate this package version
+        valuesFiles:
+          - "embedding-values.yaml"
+    images:
+      - ghcr.io/defenseunicorns/leapfrogai/text-embeddings:###ZARF_PKG_TMPL_IMAGE_VERSION###

--- a/packages/vllm/Dockerfile
+++ b/packages/vllm/Dockerfile
@@ -38,6 +38,7 @@ COPY build/*.whl build/
 COPY build/leapfrogai_api*.whl leapfrogai_api-100.100.100-py3-none-any.whl
 RUN pip install "leapfrogai_api-100.100.100-py3-none-any.whl[vllm]" --no-index --find-links=build/
 
+
 # download model
 ARG REPO_ID=TheBloke/Synthia-7B-v2.0-AWQ
 ARG REVISION=main

--- a/packages/vllm/chart/values.yaml
+++ b/packages/vllm/chart/values.yaml
@@ -45,7 +45,7 @@ resources:
   limits:
     cpu: 0
     memory: 0
-    nvidia.com/gpu: 0
+    nvidia.com/gpu: 1
   requests:
     cpu: 0
     memory: 0

--- a/packages/whisper/Dockerfile
+++ b/packages/whisper/Dockerfile
@@ -1,0 +1,50 @@
+FROM --platform=$BUILDPLATFORM ghcr.io/defenseunicorns/leapfrogai/python:3.11-dev as builder
+
+WORKDIR /leapfrogai
+
+# create virtual environment for light-weight portability and minimal libraries
+RUN python3.11 -m venv .venv
+ENV PATH="/leapfrogai/.venv/bin:$PATH"
+
+# download and covnert OpenAI's whisper base
+# TOOD @JPERRY: Move this model download to a separate build stage (within its own FROM section)
+#               We don't dirty our .venv with libraries only needed for model download...
+ARG MODEL_NAME=openai/whisper-base
+RUN pip install transformers[torch]
+RUN pip install ctranslate2
+RUN ct2-transformers-converter --model ${MODEL_NAME} --output_dir .model --copy_files tokenizer.json --quantization float32
+
+COPY build/*.whl build/
+COPY build/*.tar.gz build/
+COPY build/leapfrogai_api*.whl leapfrogai_api-100.100.100-py3-none-any.whl
+
+RUN pip install build/*.tar.gz --no-deps
+RUN pip install leapfrogai_api-100.100.100-py3-none-any.whl[whisper]
+
+# Use hardened ffmpeg image to get compiled binaries
+FROM cgr.dev/chainguard/ffmpeg:latest as ffmpeg
+
+# hardened and slim python image
+FROM --platform=$BUILDPLATFORM ghcr.io/defenseunicorns/leapfrogai/python:3.11
+
+ENV PATH="/leapfrogai/.venv/bin:$PATH"
+
+WORKDIR /leapfrogai
+
+COPY --from=ffmpeg /usr/bin/ffmpeg /usr/bin
+COPY --from=ffmpeg /usr/bin/ffprobe /usr/bin
+COPY --from=ffmpeg /usr/lib/lib* /usr/lib
+
+COPY --from=builder /leapfrogai/.venv/ /leapfrogai/.venv/
+COPY --from=builder /leapfrogai/.model/ /leapfrogai/.model/
+
+# set the path to the cuda 11.8 dependencies
+ENV LD_LIBRARY_PATH \
+/leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cublas/lib:\
+/leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cudnn/lib
+
+COPY main.py .
+
+EXPOSE 50051:50051
+
+ENTRYPOINT ["python", "-u", "main.py"]

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -1,0 +1,9 @@
+# LeapfrogAI Whisper Backend
+
+A LeapfrogAI API-compatible [whisper](https://huggingface.co/openai/whisper-base) wrapper for audio transcription inferencing across CPU & GPU infrastructures.
+
+
+# Usage
+
+:construction_worker: This documentation is still under construction. :construction_worker:
+

--- a/packages/whisper/chart/Chart.yaml
+++ b/packages/whisper/chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: leapfrogai-model
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.4.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.4.2"

--- a/packages/whisper/chart/templates/NOTES.txt
+++ b/packages/whisper/chart/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Please enjoy your model! - Defense Unicorns

--- a/packages/whisper/chart/templates/_helpers.tpl
+++ b/packages/whisper/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+app: {{ include "chart.fullname" . }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/packages/whisper/chart/templates/configmap.yaml
+++ b/packages/whisper/chart/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Values.nameOverride }}-configmap"
+  namespace: leapfrogai
+  labels:
+    leapfrogai: sparkle
+data:
+  models.toml: |
+    [[models]]
+        owned_by    = 'Defense Unicorns'
+        backend     = '{{ include "chart.fullname" . }}:50051'
+        type        = 'gRPC'
+        name        = '{{ .Values.nameOverride }}'

--- a/packages/whisper/chart/templates/deployment.yaml
+++ b/packages/whisper/chart/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: GPU_REQUEST
+              value: {{ (index .Values.resources.requests "nvidia.com/gpu") | default "0"}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/whisper/chart/templates/hpa.yaml
+++ b/packages/whisper/chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/packages/whisper/chart/templates/service.yaml
+++ b/packages/whisper/chart/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  annotations:
+    zarf.dev/connect-description: "{{ .Values.nameOverride }} gRPC endpoint."
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    zarf.dev/connect-name: "{{ .Values.nameOverride }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 50051
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/packages/whisper/chart/templates/serviceaccount.yaml
+++ b/packages/whisper/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/packages/whisper/chart/values.yaml
+++ b/packages/whisper/chart/values.yaml
@@ -1,0 +1,66 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: "ghcr.io/defenseunicorns/leapfrogai/whisper"
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: 0.0.1 #TODO: Validate this package version exists
+
+imagePullSecrets: []
+nameOverride: whisper
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+
+securityContext:
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+
+service:
+  type: ClusterIP
+  port: 50051
+
+gpuEnabled: false 
+
+resources: 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 0
+    memory: 0
+    nvidia.com/gpu: 0
+  requests:
+    cpu: 0
+    memory: 0
+    nvidia.com/gpu: 0
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/packages/whisper/main.py
+++ b/packages/whisper/main.py
@@ -1,0 +1,92 @@
+import asyncio
+import logging
+import os
+import tempfile
+from typing import Iterator
+
+import leapfrogai_api.types as lfai_types
+from faster_whisper import WhisperModel
+
+logger = logging.getLogger(__name__)
+
+model_path = ".model"
+
+GPU_ENABLED = True if int(os.environ.get("GPU_REQUEST", 0)) > 0 else False
+
+
+def make_transcribe_request(filename, task, language, temperature, prompt):
+    # TODO @JPERRY does this make sense to be in the function? This seems like something that should be done during initialization
+    device = "cuda" if GPU_ENABLED else "cpu"
+    model = WhisperModel(model_path, device=device, compute_type="float32")
+
+    segments, info = model.transcribe(filename, beam_size=5)
+
+    output = ""
+
+    for segment in segments:
+        output += segment.text
+
+    logger.info("Completed " + filename)
+
+    return {"text": output}
+
+
+def call_whisper(
+    request_iterator: Iterator[lfai_types.AudioRequest], task: str
+) -> lfai_types.AudioResponse:
+    data = bytearray()
+    prompt = ""
+    temperature = 0.0
+    inputLanguage = "en"
+
+    for request in request_iterator:
+        if (
+            request.metadata.prompt
+            and request.metadata.temperature
+            and request.metadata.inputlanguage
+        ):
+            prompt = request.metadata.prompt
+            temperature = request.metadata.temperature
+            inputLanguage = request.metadata.inputlanguage
+            audioFormat = request.metadata.format
+            continue
+
+        data.extend(request.chunk_data)
+
+    with tempfile.NamedTemporaryFile("wb") as f:
+        f.write(data)
+        result = make_transcribe_request(
+            f.name, task, inputLanguage, temperature, prompt
+        )
+        text = str(result["text"])
+        logger.info("Transcription complete!")
+        return lfai_types.AudioResponse(text=text)
+
+
+class Whisper(lfai_types.AudioServicer):
+    def Translate(
+        self,
+        request_iterator: Iterator[lfai_types.AudioRequest],
+        context: lfai_types.GrpcContext,
+    ):
+        return call_whisper(request_iterator, "translate")
+
+    def Transcribe(
+        self,
+        request_iterator: Iterator[lfai_types.AudioRequest],
+        context: lfai_types.GrpcContext,
+    ):
+        return call_whisper(request_iterator, "transcribe")
+
+    def Name(self, request, context):
+        return lfai_types.NameResponse(name="whisper")
+
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+    logger.info(f"GPU_ENABLED = {GPU_ENABLED}")
+    await lfai_types.serve(Whisper())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/whisper/whisper-values.yaml
+++ b/packages/whisper/whisper-values.yaml
@@ -1,0 +1,11 @@
+image:
+  tag: "###ZARF_CONST_IMAGE_VERSION###"
+
+
+# NOTE: This is not a typo, the request and limit values NEED to be the same
+# TODO @JPERRY: Is there a better way to name this variable to make that more clear without needing to read the above comment?
+resources:
+  requests:
+    nvidia.com/gpu: "###ZARF_VAR_REQUESTS_GPU###"
+  limits:
+    nvidia.com/gpu: "###ZARF_VAR_REQUESTS_GPU###"

--- a/packages/whisper/zarf.yaml
+++ b/packages/whisper/zarf.yaml
@@ -1,0 +1,24 @@
+kind: ZarfPackageConfig
+metadata:
+  name: "whisper"
+  version: 0.0.1
+  description: >
+    whisper model
+
+constants:
+  - name: IMAGE_VERSION
+    value: "###ZARF_PKG_TMPL_IMAGE_VERSION###"
+
+components:
+  - name: whisper-model
+    required: true
+    charts:
+      - name: whisper-model
+        namespace: leapfrogai
+        localPath: chart
+        releaseName: whisper-model
+        version: 0.0.1 #TODO: Validate this package version
+        valuesFiles:
+          - "whisper-values.yaml"
+    images:
+      - ghcr.io/defenseunicorns/leapfrogai/whisper:###ZARF_PKG_TMPL_IMAGE_VERSION###

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,15 @@ vllm = [
     "aiostream>=0.5.2",
 ]
 
+text-embeddings = [
+    "InstructorEmbedding >= 1.0.1",
+    "torch == 2.1.2",
+    "numpy == 1.26.3",
+    "tqdm == 4.66.1",
+    "sentence-transformers == 2.2.2",
+    "transformers == 4.36.0",
+]
+
 [tool.pip-tools]
 generate-hashes = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,11 @@ text-embeddings = [
     "transformers == 4.36.0",
 ]
 
+whisper = [
+    "faster-whisper == 0.10.0",
+]
+
+
 [tool.pip-tools]
 generate-hashes = true
 


### PR DESCRIPTION
This PR consolidates the functional bits from the following repositories:

https://github.com/defenseunicorns/leapfrogai-backend-text-embeddings