### PR TITLE
UDS Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,11 @@ Large Language Models (LLMs) are a powerful resource for AI-driven decision maki
 
 ### UDS
 
-UDS is the preferrred method for a full local deployment of LeapfrogAI. Instructions can be found on the [LeapfrogAI Documentation Site](https://docs.leapfrog.ai/docs/).
+The preferred method for running LeapfrogAI is a local [Kubernetes](https://kubernetes.io/) deployment using [UDS](https://github.com/defenseunicorns/uds-core). Simple instructions for this type of deployment can be found on the [LeapfrogAI Documentation Site](https://docs.leapfrog.ai/docs/).
 
 ### Tadpole
 
-> GitHub Repo:
->
-> - [Tadpole](https://github.com/defenseunicorns/tadpole)
-
-Tadpole is a simple way to get LeapfrogAI up and running in a sandbox environment. While not intended for production, it helps the user to understand the various components of LeapfrogAI and how they interact.
+[Tadpole](https://github.com/defenseunicorns/tadpole) is a simple, lightweight way to get LeapfrogAI up and running in a sandbox environment using Docker. While not intended for production, it helps the user to understand the various components of LeapfrogAI and how they interact.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 - [Table of Contents](#table-of-contents)
 - [Overview](#overview)
 - [Why Host Your Own LLM?](#why-host-your-own-llm)
+- [Getting Started](#getting-started)
+  - [UDS](#uds)
+  - [Tadpole](#tadpole)
 - [Components](#components)
-  - [Getting Started](#getting-started)
   - [API](#api)
   - [Backends](#backends)
   - [Image Hardening](#image-hardening)
   - [SDK](#sdk)
   - [User Interface](#user-interface)
-  - [Advanced Deployments](#advanced-deployments)
 - [Community](#community)
 
 ## Overview
@@ -32,34 +33,36 @@ Large Language Models (LLMs) are a powerful resource for AI-driven decision maki
 
 - **Mission Integration**: By hosting your own LLM, you have the ability to customize the model's parameters, training data, and more, tailoring the AI to your specific needs.
 
-## Components
+## Getting Started
 
-### Getting Started
+### UDS
+
+UDS is the preferrred method for a full local deployment of LeapfrogAI. Instructions can be found on the [LeapfrogAI Documentation Site](https://docs.leapfrog.ai/docs/).
+
+### Tadpole
 
 > GitHub Repo:
 >
 > - [Tadpole](https://github.com/defenseunicorns/tadpole)
 
-Tadpole is a simple way to get LeapfrogAI up and running locally. While not intended for production, it helps the user to understand the various components of LeapfrogAI and how they interact.
+Tadpole is a simple way to get LeapfrogAI up and running in a sandbox environment. While not intended for production, it helps the user to understand the various components of LeapfrogAI and how they interact.
+
+## Components
 
 ### API
-
-> GitHub Repo:
->
-> - [leapfrog-api](https://github.com/defenseunicorns/leapfrogai-api)
 
 LeapfrogAI provides an API that closely matches that of OpenAI's. This feature allows tools that have been built with OpenAI/ChatGPT to function seamlessly with a LeapfrogAI backend.
 
 ### Backends
 
-> GitHub Repos:
-> | Repo | AMD64 Support | ARM64 Support | Cuda Support | Docker Ready | K8s Ready | Zarf Ready |
+> Available Backends:
+> | Backend | AMD64 Support | ARM64 Support | Cuda Support | Docker Ready | K8s Ready | Zarf Ready |
 > | --- | --- | --- | --- | --- | --- | --- |
-> | [llama-cpp-python](https://github.com/defenseunicorns/leapfrogai-backend-llama-cpp-python) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | [whisper](https://github.com/defenseunicorns/leapfrogai-backend-whisper) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | [text-embeddings](https://github.com/defenseunicorns/leapfrogai-backend-text-embeddings) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | [vllm](https://github.com/defenseunicorns/leapfrogai-backend-vllm) | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
-> | [rag](https://github.com/defenseunicorns/leapfrogai-backend-rag) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+> | llama-cpp-python | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | whisper | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | text-embeddings | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | vllm | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+> | [rag](https://github.com/defenseunicorns/leapfrogai-backend-rag) (repo integration soon) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 
 LeapfrogAI provides several backends for a variety of use cases.
 
@@ -73,8 +76,6 @@ LeapfrogAI leverages Chainguard's [apko](https://github.com/chainguard-dev/apko)
 
 ### SDK
 
-> GitHub Repo: [leapfrogai-sdk](https://github.com/defenseunicorns/leapfrogai-sdk)
-
 The LeapfrogAI SDK provides a standard set of protobuff and python utilities for implementing backends and gRPC.
 
 ### User Interface
@@ -84,14 +85,6 @@ The LeapfrogAI SDK provides a standard set of protobuff and python utilities for
 > - [leapfrog-ui](https://github.com/defenseunicorns/leapfrog-ui)
 
 LeapfrogAI provides some options of UI to get started with common use-cases such as chat, summarization, and transcription.
-
-### Advanced Deployments
-
-> GitHub Repo:
->
-> - [leapfrogai-deployment](https://github.com/defenseunicorns/leapfrogai-deployment)
-
-These instructions will assist advanced users in standing up the latest production version of LeapfrogAI on Kubernetes.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 - [Overview](#overview)
 - [Why Host Your Own LLM?](#why-host-your-own-llm)
 - [Getting Started](#getting-started)
-  - [UDS](#uds)
-  - [Tadpole](#tadpole)
 - [Components](#components)
   - [API](#api)
   - [Backends](#backends)
@@ -35,13 +33,7 @@ Large Language Models (LLMs) are a powerful resource for AI-driven decision maki
 
 ## Getting Started
 
-### UDS
-
 The preferred method for running LeapfrogAI is a local [Kubernetes](https://kubernetes.io/) deployment using [UDS](https://github.com/defenseunicorns/uds-core). Simple instructions for this type of deployment can be found on the [LeapfrogAI Documentation Site](https://docs.leapfrog.ai/docs/).
-
-### Tadpole
-
-[Tadpole](https://github.com/defenseunicorns/tadpole) is a simple, lightweight way to get LeapfrogAI up and running in a sandbox environment using Docker. While not intended for production, it helps the user to understand the various components of LeapfrogAI and how they interact.
 
 ## Components
 
@@ -54,10 +46,10 @@ LeapfrogAI provides an API that closely matches that of OpenAI's. This feature a
 > Available Backends:
 > | Backend | AMD64 Support | ARM64 Support | Cuda Support | Docker Ready | K8s Ready | Zarf Ready |
 > | --- | --- | --- | --- | --- | --- | --- |
-> | llama-cpp-python | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | whisper | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | text-embeddings | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
-> | vllm | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+> | [llama-cpp-python](packages/llama-cpp-python/) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | [whisper](packages/whisper/) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | [text-embeddings](packages/text-embeddings/) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
+> | [vllm](packages/vllm/) | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 > | [rag](https://github.com/defenseunicorns/leapfrogai-backend-rag) (repo integration soon) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 
 LeapfrogAI provides several backends for a variety of use cases.

--- a/website/content/en/docs/leapfrogai/tadpole/tadpole-deploy.md
+++ b/website/content/en/docs/leapfrogai/tadpole/tadpole-deploy.md
@@ -1,6 +1,7 @@
 ---
 title: Sandbox Deployment
 type: docs
+draft: true
 ---
 
 ## Overview

--- a/website/content/en/docs/local deploy guide/components.md
+++ b/website/content/en/docs/local deploy guide/components.md
@@ -6,17 +6,9 @@ weight: 3
 
 ## Components
 
-### Sandbox Deployment
-
-[Tadpole](https://github.com/defenseunicorns/tadpole) serves as a straightforward method to set up LeapfrogAI for local use. Although **not suitable for production environments**, it aids users in understanding the different components of LeapfrogAI and their interactions.
-
-### Advanced LeapfrogAI Deployment
-
-The LeapfrogAI deployment guide is designed to guide advanced users through the process of deploying the latest production version of LeapfrogAI locally on Kubernetes.
-
 ### LeapfrogAI API
 
-LeapfrogAI offers an [API](https://github.com/defenseunicorns/leapfrogai-api) closely aligned with OpenAI's, facilitating seamless compatibility for tools developed with OpenAI/ChatGPT to operate seamlessly with a LeapfrogAI backend. The LeapfrogAI API is a Python API that exposes LLM backends, via FastAPI and gRPC, in the OpenAI API specification.
+LeapfrogAI offers an API closely aligned with OpenAI's, facilitating seamless compatibility for tools developed with OpenAI/ChatGPT to operate seamlessly with a LeapfrogAI backend. The LeapfrogAI API is a Python API that exposes LLM backends, via FastAPI and gRPC, in the OpenAI API specification.
 
 ### Backend
 
@@ -24,10 +16,10 @@ LeapfrogAI offers several backends for a variety of use cases:
 
 | Backend                                                                                    | Support                         |
 | ------------------------------------------------------------------------------------------ | ------------------------------- |
-| [llama-cpp-python](https://github.com/defenseunicorns/leapfrogai-backend-llama-cpp-python) | AMD64, Docker, Kubernetes, Zarf |
-| [whisper](https://github.com/defenseunicorns/leapfrogai-backend-whisper)                   | AMD64, Docker, Kubernetes, Zarf |
-| [text-embeddings](https://github.com/defenseunicorns/leapfrogai-backend-text-embeddings)   | AMD64, Docker, Kubernetes, Zarf |
-| [VLLM](https://github.com/defenseunicorns/leapfrogai-backend-vllm)                         | AMD64, Docker, Kubernetes, Zarf |
+| [llama-cpp-python](https://github.com/defenseunicorns/leapfrogai/tree/main/packages/llama-cpp-python) | AMD64, Docker, Kubernetes, Zarf |
+| [whisper](https://github.com/defenseunicorns/leapfrogai/tree/main/packages/whisper)                   | AMD64, Docker, Kubernetes, Zarf |
+| [text-embeddings](https://github.com/defenseunicorns/leapfrogai/tree/main/packages/text-embeddings)   | AMD64, Docker, Kubernetes, Zarf |
+| [VLLM](https://github.com/defenseunicorns/leapfrogai/tree/main/packages/vllm)                         | AMD64, Docker, Kubernetes, Zarf |
 | [RAG](https://github.com/defenseunicorns/leapfrogai-backend-rag)                           | AMD64, Docker, Kubernetes, Zarf |
 
 ### Image Hardening

--- a/website/content/en/docs/local deploy guide/components.md
+++ b/website/content/en/docs/local deploy guide/components.md
@@ -1,7 +1,7 @@
 ---
 title: Components 
 type: docs
-weight: 2
+weight: 3
 ---
 
 ## Components

--- a/website/content/en/docs/local deploy guide/dependencies.md
+++ b/website/content/en/docs/local deploy guide/dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Dependencies 
 type: docs
-weight: 4
+weight: 5
 ---
 
 This documentation addresses the local deployment dependencies of LeapfrogAI, a self-hosted generative AI platform. LeapfrogAI extends the diverse capabilities and modalities of AI models to various environments, ranging from cloud-based deployments to servers with ingress and egress limitations. With LeapfrogAI, teams can deploy APIs aligned with OpenAI's API specifications, empowering teams to create and utilize tools compatible with nearly any model and code library available. Importantly, all operations take place locally, ensuring users can maintain the security of their information and sensitive data within their own environments

--- a/website/content/en/docs/local deploy guide/deploy.md
+++ b/website/content/en/docs/local deploy guide/deploy.md
@@ -1,12 +1,10 @@
 ---
-title: Deployment (deprecated)
+title: Advanced Deployments & Air Gap
 type: docs
 weight: 6
 ---
 
-**THIS INSTRUCTION SET IS DEPRECATED AND IS NO LONGER BEING MAINTAINED**
-
-**IT IS HIGHLY RECOMMENDED TO USE THE QUICK START DEPLOYMENT INSTRUCTIONS**
+These instructions are for users who are looking for a more customizable deployment of LeapfrogAI or require air gap deployment considerations.
 
 To successfully proceed with the installation and deployment of LeapfrogAI, steps must be executed in the order that they are presented in the following instructions. The LeapfrogAI deployment instructions are designed to guide advanced users through the process of deploying the latest version of LeapfrogAI on Kubernetes.
 

--- a/website/content/en/docs/local deploy guide/deploy.md
+++ b/website/content/en/docs/local deploy guide/deploy.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment 
 type: docs
-weight: 5
+weight: 6
 ---
 
 To successfully proceed with the installation and deployment of LeapfrogAI, steps must be executed in the order that they are presented in the following instructions. The LeapfrogAI deployment instructions are designed to guide advanced users through the process of deploying the latest version of LeapfrogAI on Kubernetes.

--- a/website/content/en/docs/local deploy guide/deploy.md
+++ b/website/content/en/docs/local deploy guide/deploy.md
@@ -1,8 +1,12 @@
 ---
-title: Deployment 
+title: Deployment (deprecated)
 type: docs
 weight: 6
 ---
+
+**THIS INSTRUCTION SET IS DEPRECATED AND IS NO LONGER BEING MAINTAINED**
+
+**IT IS HIGHLY RECOMMENDED TO USE THE QUICK START DEPLOYMENT INSTRUCTIONS**
 
 To successfully proceed with the installation and deployment of LeapfrogAI, steps must be executed in the order that they are presented in the following instructions. The LeapfrogAI deployment instructions are designed to guide advanced users through the process of deploying the latest version of LeapfrogAI on Kubernetes.
 

--- a/website/content/en/docs/local deploy guide/quick_start.md
+++ b/website/content/en/docs/local deploy guide/quick_start.md
@@ -38,7 +38,7 @@ These `vllm` specific environment variables must be set at the model skeleton le
 
 ## Instructions
 
-Start by cloning the repository which contain the LeapfrogAI UDS bundles:
+Start by cloning the repository which contains the LeapfrogAI UDS bundles:
 
 ``` bash
 git clone https://github.com/defenseunicorns/uds-leapfrogai.git

--- a/website/content/en/docs/local deploy guide/quick_start.md
+++ b/website/content/en/docs/local deploy guide/quick_start.md
@@ -1,0 +1,84 @@
+---
+title: Quick Start
+type: docs
+weight: 2
+---
+
+# LeapfrogAI UDS Deployment
+
+The fastest and easiest way to get started with a deployment of LeapfrogAI is by using [UDS](https://github.com/defenseunicorns/uds-core). These quick start instructions show how to deploy LeapfrogAI in either a CPU or GPU-enabled environment.
+
+## Prerequisites
+
+- [K3D](https://k3d.io/)
+- [UDS CLI](https://github.com/defenseunicorns/uds-cli)
+
+GPU considerations (NVIDIA GPUs only):
+
+- NVIDIA GPU must have the most up-to-date drivers installed.
+- NVIDIA GPU drivers compatible with CUDA (>=12.2).
+- NVIDIA Container Toolkit is available via internet access, pre-installed, or on a mirrored package repository in the air gap.
+
+## Disclaimers
+
+GPU workloads **_WILL NOT_** run if GPU resources are unavailable to the pod(s). You must provide sufficient NVIDIA GPU scheduling or else the pod(s) will go into a crash loop.
+
+`whisper` can run without without GPU scheduling - just turn off the `GPU_ENABLED` boolean.
+
+If `vllm` is being used with:
+
+- A quantized model, then `QUANTIZATION` must be set to the quantization method (e.g., `awq`, `gptq`, etc.)
+- Tensor parallelism for spreading a model's heads across multiple GPUs, then `TENSOR_PARALLEL_SIZE` must be set to an integer value that:
+  a) falls within the number of GPU resources (`nvidia.com/gpu`) that are allocatable in the cluster
+  b) divisible by the number of attention heads in the model architecture (if number of heads is 32, then `TENSOR_PARALLEL_SIZE` could be 2, 4, etc.)
+
+These `vllm` specific environment variables must be set at the model skeleton level or when the model is deployed into the cluster.
+
+## Instructions
+
+Start by cloning the repository which contain the LeapfrogAI UDS bundles:
+
+``` bash
+git clone https://github.com/defenseunicorns/uds-leapfrogai.git
+```
+
+### CPU
+
+From within the cloned repository, deploy K3D and the LeapfrogAI bundle:
+
+``` bash
+cd bundles/cpu/
+uds create .
+uds deploy k3d-core-istio-dev:0.14.1
+uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
+```
+
+### GPU
+
+In order to test the GPU deployment locally on K3d, use the following command when deploying UDS-Core:
+
+```bash
+ cd bundles/gpu/
+ uds create .
+ uds deploy k3d-core-istio-dev:0.14.1 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"
+ uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
+```
+
+## Checking Deployment
+
+Inspect the cluster using:
+
+```bash
+uds zarf tools monitor
+```
+
+| Tool       | URL                                   |
+| ---------- | ------------------------------------- |
+| UI         | <https://ai.uds.dev>                  |
+| API        | <https://leapfrogai-api.uds.dev/docs> |
+| RAG Server | <https://leapfrogai-rag.uds.dev/docs> |
+
+## References
+
+- [UDS-Core](https://github.com/defenseunicorns/uds-core)
+

--- a/website/content/en/docs/local deploy guide/quick_start.md
+++ b/website/content/en/docs/local deploy guide/quick_start.md
@@ -10,6 +10,7 @@ The fastest and easiest way to get started with a deployment of LeapfrogAI is by
 
 ## Prerequisites
 
+- [Docker](https://docs.docker.com/engine/install/)
 - [K3D](https://k3d.io/)
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli)
 
@@ -21,11 +22,9 @@ GPU considerations (NVIDIA GPUs only):
 
 ## Disclaimers
 
-It is recommended to run UDS as root.
-
 GPU workloads **_WILL NOT_** run if GPU resources are unavailable to the pod(s). You must provide sufficient NVIDIA GPU scheduling or else the pod(s) will go into a crash loop.
 
-`whisper` can run without without GPU scheduling - just turn off the `GPU_ENABLED` boolean.
+`whisper` can run without GPU scheduling - just set the `GPU_LIMIT` value to `0`.
 
 If `vllm` is being used with:
 
@@ -51,7 +50,7 @@ From within the cloned repository, deploy K3D and the LeapfrogAI bundle:
 ``` bash
 cd bundles/cpu/
 uds create .
-uds deploy k3d-core-istio-dev:0.14.1
+uds deploy k3d-core-istio-dev:0.14.1      # be sure to check if a newer version exists
 uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
 ```
 
@@ -62,7 +61,7 @@ In order to test the GPU deployment locally on K3d, use the following command wh
 ```bash
  cd bundles/gpu/
  uds create .
- uds deploy k3d-core-istio-dev:0.14.1 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"
+ uds deploy k3d-core-istio-dev:0.14.1 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"     # be sure to check if a newer version exists
  uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
 ```
 

--- a/website/content/en/docs/local deploy guide/quick_start.md
+++ b/website/content/en/docs/local deploy guide/quick_start.md
@@ -21,6 +21,8 @@ GPU considerations (NVIDIA GPUs only):
 
 ## Disclaimers
 
+It is recommended to run UDS as root.
+
 GPU workloads **_WILL NOT_** run if GPU resources are unavailable to the pod(s). You must provide sufficient NVIDIA GPU scheduling or else the pod(s) will go into a crash loop.
 
 `whisper` can run without without GPU scheduling - just turn off the `GPU_ENABLED` boolean.

--- a/website/content/en/docs/local deploy guide/requirements.md
+++ b/website/content/en/docs/local deploy guide/requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Requirements 
 type: docs
-weight: 3
+weight: 4
 ---
 
 Prior to deploying LeapfrogAI, ensure that the following tools, packages, and requirements are met and present in your environment.


### PR DESCRIPTION
Quick PR to update some the documentation:
- Point people to use UDS to deploy LFAI
- Deprecate instructions for k8s deployment that doesn't use UDS
- Minor other doc fixes

The plan is to adjust this documentation (and add more) once #322 gets finalized, but this documentation is up to date at the moment.