### PR TITLE
chore: add zarf.yaml schema and set useful component names

### DIFF
--- a/packages/llama-cpp-python/zarf.yaml
+++ b/packages/llama-cpp-python/zarf.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+
 kind: ZarfPackageConfig
 metadata:
   name: llama-cpp-python
@@ -10,7 +12,7 @@ constants:
     value: "###ZARF_PKG_TMPL_IMAGE_VERSION###"
 
 components:
-  - name: import-model
+  - name: llama-cpp-python-model
     required: true
     charts:
       - name: llama-cpp-python-model

--- a/packages/text-embeddings/zarf.yaml
+++ b/packages/text-embeddings/zarf.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+
 kind: ZarfPackageConfig
 metadata:
   name: text-embeddings

--- a/packages/vllm/zarf.yaml
+++ b/packages/vllm/zarf.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
 kind: ZarfPackageConfig
 metadata:
   name: vllm
@@ -10,7 +11,7 @@ constants:
     value: "###ZARF_PKG_TMPL_IMAGE_VERSION###"
 
 components:
-  - name: import-model
+  - name: vllm-model
     required: true
     charts:
       - name: vllm-model

--- a/packages/whisper/zarf.yaml
+++ b/packages/whisper/zarf.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/main/zarf.schema.json
+
 kind: ZarfPackageConfig
 metadata:
   name: "whisper"


### PR DESCRIPTION
This PR cleans up our various zarf.yaml files a little.

It also adds a `yaml-language-server` tag so IDEs can give better type hints.