### PR TITLE
chore: remove redundant optional dependencies within our pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ source .venv/bin/activate
 To run the LeapfrogAI API locally (starting from the root directory of the repository):
 
 ```
-python -m pip install ".[api,dev]"
+python -m pip install ".[dev]"
 cd src
 uvicorn leapfrogai_api.main:app --port 3000 --reload
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,28 +20,6 @@ readme = "README.md"
 
 [project.optional-dependencies]
 
-# NOTE @JPERRY: I have removed 'toml >= 0.10.2', 'pydantic >= 2.3.0', and 'pyyaml >= 6.0.1'
-# TODO @JPERRY: These deps are no in the core 'dependencies' list. Consider removing this list.
-api = [
-    "fastapi >= 0.109.1",
-    "uvicorn >= 0.23.2",
-    "pydantic",
-    "python-multipart >= 0.0.7", #indirect dep of FastAPI to receive form data for file uploads
-    "watchfiles >= 0.21.0",
-]
-
-# TODO @JPERRY: These deps are no in the core 'dependencies' list. Consider removing this list.
-sdk = [
-    "grpcio >= 1.56.0",
-    "grpcio-tools >= 1.62.1",
-    "protobuf >= 4.23.3",
-    "grpcio-reflection >=1.58.0",
-    "grpcio-health-checking >=1.58.0",
-    "confz >= 2.0.1",
-    "pydantic >= 2.0",
-    "click >= 8.1.7",
-]
-
 dev = [
     "pip-tools == 7.3.0",
     "pytest",


### PR DESCRIPTION
This PR removes the optional-dependencies `api` and `sdk`. All of the libraries listed in these sections are already listed in the default dependencies location which meant nothing new was being introduced.