### PR TITLE
fix: correct typos in e2e workflow path triggers

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,7 +7,7 @@ on:
 
       # Ignore updates to the .github directory, unless it's this current file
       - "!.github/**"
-      - ".github/workflows/e2e.yml"
+      - ".github/workflows/e2e.yaml"
 
       # Ignore docs and website things
       - "!**.md"
@@ -24,7 +24,7 @@ on:
       - "!pre-commit-config.yaml"
 
       # Ignore non e2e tests
-      - "!tests/e2e/**"
+      - "!tests/pytest/**"
 
 
 concurrency:


### PR DESCRIPTION
Fixes a typo where the incorrect yaml shorthand was used for the `e2e.yaml` file.

Fixes a logical error when we ignored the wrong directory