### PR TITLE
chore: create shim e2e workflow

### DIFF
--- a/.github/workflows/e2e-shim.yaml
+++ b/.github/workflows/e2e-shim.yaml
@@ -1,0 +1,51 @@
+# Catch all the things we ignore in the e2e workflow
+name: e2e Skip Shim
+on:
+  pull_request:
+    paths:
+      # Catch updates to the .github directory, unless it is the e2e.yaml files
+      - ".github/**"
+      - "!.github/workflows/e2e.yaml"
+
+      # Catch docs and website things
+      - "**.md"
+      - "docs/**"
+      - "website/**"
+      - "netlify.toml"
+
+      # Catch generic github metadata files
+      - "CODEOWNERS"
+      - ".gitignore"
+      - "LICENSE"
+      - "pre-comimt-config.yaml"
+
+      # Catch pytests
+      - "tests/pytest/**"
+
+
+permissions:
+  contents: read
+
+# This is here to act as a shim for branch protection rules to work correctly.
+# This is ugly but this seems to be the best way to do this since:
+#  - Job names in a workflow must be unique
+#  - When paths are ignored not all jobs are reported to the branch protection rules
+#  - Multiple jobs of the same name are still required by branch protection rules
+
+# For more info see below:
+# https://github.com/orgs/community/discussions/54877
+# https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+# Abort prior jobs in the same workflow / PR
+concurrency:
+  group: e2e-skip-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skipped
+        run: |
+          echo skipped

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,7 +7,7 @@ on:
 
       # Ignore updates to the .github directory, unless it's this current file
       - "!.github/**"
-      - ".github/workflows/e2e.yml"
+      - ".github/workflows/e2e.yaml"
 
       # Ignore docs and website things
       - "!**.md"
@@ -24,7 +24,7 @@ on:
       - "!pre-commit-config.yaml"
 
       # Ignore non e2e tests
-      - "!tests/e2e/**"
+      - "!tests/pytest/**"
 
 
 concurrency:


### PR DESCRIPTION
Note: Merge this AFTER #376 

---

This shim workflow runs when the real e2e workflow does not run. This allows us to have branch protection rules that expect the e2e workflow to pass. 


The inspiration for this repo is from [this zarf shim workflow](https://github.com/defenseunicorns/zarf/blob/main/.github/workflows/test-e2e-shim.yml)


