### PR TITLE
chore(ci): always run the pytest workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,16 +1,5 @@
 name: pytest
-on:
-  pull_request:
-    paths-ignore:
-    - "**.md"
-    - "CODEOWNERS"
-    - "CONTRIBUTING.md"
-    - ".gitignore"
-    - "docs/**"
-    - "adr/**"
-    - "website/**"
-    - "tests/e2e/**"
-    - "packages/**"
+on: [pull_request]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
The pytest workflow runs really quickly and is extremely lightweight. It probably makes sense to always run it to try to catch errors early and not have to worry about creating a 'shim-workflow' so that we can have branch protection rules.