### PR TITLE
bug: remove hardcoded gpu request value

### DIFF
--- a/packages/text-embeddings/chart/values.yaml
+++ b/packages/text-embeddings/chart/values.yaml
@@ -39,7 +39,6 @@ resources:
   requests:
     cpu: 0
     memory: 0
-    nvidia.com/gpu: 0
 
 autoscaling:
   enabled: false

--- a/packages/whisper/chart/values.yaml
+++ b/packages/whisper/chart/values.yaml
@@ -39,7 +39,6 @@ resources:
   requests:
     cpu: 0
     memory: 0
-    nvidia.com/gpu: 0
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Fixes #385 

We were overriding the `nvidia.com/gpu` limit but not the request. Because we [only need the limit to be set](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) this PR removes the request from the values.yaml.