### PR TITLE
chore: restrict e2e tests from running on lfai-ui changes

### DIFF
--- a/.github/workflows/e2e-shim.yaml
+++ b/.github/workflows/e2e-shim.yaml
@@ -22,6 +22,10 @@ on:
       # Catch pytests
       - "tests/pytest/**"
 
+      # Catch LFAI-UI things
+      - "src/leapfrogai_ui/**"
+      - "packages/ui/**"
+
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,10 @@ on:
       # Ignore non e2e tests
       - "!tests/pytest/**"
 
+      # Ignore LFAI-UI things (for now?)
+      - "!src/leapfrogai_ui/**"
+      - "!packages/ui/**"
+
 
 concurrency:
   group: e2e-${{ github.ref }}


### PR DESCRIPTION
We don't have any e2e tests that test against the LFAI-UI yet, so it doesn't make sense to use runner time when only UI changes are commited.

We should add workflows that test the UI sooner than later though...