### PR TITLE
fix: send and cancel btn tooltips

### DIFF
--- a/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/+page.svelte
+++ b/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/+page.svelte
@@ -160,21 +160,21 @@
 			/>
 			{#if !$isLoading}
 				<Button
+					data-testid="send message"
 					kind="secondary"
 					icon={ArrowRight}
 					size="field"
 					type="submit"
-					aria-label="send message"
 					iconDescription="send"
 					disabled={$isLoading || !$input}
 				/>
 			{:else}
 				<Button
+					data-testid="cancel message"
 					kind="secondary"
 					size="field"
 					type="submit"
 					icon={StopFilledAlt}
-					aria-label="cancel message"
 					iconDescription="cancel"
 				/>
 			{/if}

--- a/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/+page.svelte
+++ b/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/+page.svelte
@@ -164,7 +164,8 @@
 					icon={ArrowRight}
 					size="field"
 					type="submit"
-					aria-label="send"
+					aria-label="send message"
+					iconDescription="send"
 					disabled={$isLoading || !$input}
 				/>
 			{:else}
@@ -174,6 +175,7 @@
 					type="submit"
 					icon={StopFilledAlt}
 					aria-label="cancel message"
+					iconDescription="cancel"
 				/>
 			{/if}
 		</div>

--- a/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/chatpage.test.ts
+++ b/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/chatpage.test.ts
@@ -51,7 +51,7 @@ describe('The Chat Page', () => {
 
 		test('the send button is disabled when there is no text in the input', () => {
 			render(ChatPage);
-			const submitBtn = screen.getByLabelText('send message');
+			const submitBtn = screen.getByTestId('send message');
 			expect(submitBtn).toHaveProperty('disabled', true);
 		});
 
@@ -99,12 +99,12 @@ describe('The Chat Page', () => {
 			await user.type(input, question);
 			await user.click(submitBtn);
 
-			expect(screen.getByLabelText('cancel message')).toBeInTheDocument();
+			expect(screen.getByTestId('cancel message')).toBeInTheDocument();
 
 			await delay(delayTime);
 
 			await user.type(input, 'new question');
-			expect(screen.queryByLabelText('cancel message')).not.toBeInTheDocument();
+			expect(screen.queryByTestId('cancel message')).not.toBeInTheDocument();
 		});
 
 		it('displays a toast error notification when there is an error with the AI response', async () => {
@@ -245,7 +245,7 @@ describe('The Chat Page', () => {
 				await user.type(input, question);
 				await user.click(submitBtn);
 				await delay(delayTime / 2);
-				const cancelBtn = screen.getByLabelText('cancel message');
+				const cancelBtn = screen.getByTestId('cancel message');
 				await user.click(cancelBtn);
 
 				await screen.findAllByText('Response Canceled');

--- a/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/chatpage.test.ts
+++ b/src/leapfrogai_ui/src/routes/(dashboard)/chat/[[conversation_id]]/chatpage.test.ts
@@ -51,7 +51,7 @@ describe('The Chat Page', () => {
 
 		test('the send button is disabled when there is no text in the input', () => {
 			render(ChatPage);
-			const submitBtn = screen.getByLabelText('send');
+			const submitBtn = screen.getByLabelText('send message');
 			expect(submitBtn).toHaveProperty('disabled', true);
 		});
 

--- a/src/leapfrogai_ui/tests/chat.test.ts
+++ b/src/leapfrogai_ui/tests/chat.test.ts
@@ -65,7 +65,7 @@ test('it cancels responses', async ({ page }) => {
 	await sendMessage(page, newMessage);
 	await expect(messages).toHaveCount(2); // ensure new response is being received
 	await page.waitForTimeout(300); // let it partially complete
-	await page.getByLabel('cancel message').click();
+	await page.getByTestId('cancel message').click();
 	await page.waitForTimeout(200); // wait to ensure new question was not sent
 	await expect(messages).toHaveCount(2);
 	const allMessages = await messages.all();

--- a/src/leapfrogai_ui/tests/helpers.ts
+++ b/src/leapfrogai_ui/tests/helpers.ts
@@ -26,7 +26,7 @@ export const deleteConversationsByLabel = async (labels: string[]) => {
 };
 
 export const waitForResponseToComplete = async (page: Page) => {
-	await expect(page.getByLabel('cancel message')).toHaveCount(1, { timeout: 25000 });
-	await expect(page.getByLabel('cancel message')).toHaveCount(0, { timeout: 25000 });
-	await expect(page.getByLabel('send message')).toHaveCount(1, { timeout: 25000 });
+	await expect(page.getByTestId('cancel message')).toHaveCount(1, { timeout: 25000 });
+	await expect(page.getByTestId('cancel message')).toHaveCount(0, { timeout: 25000 });
+	await expect(page.getByTestId('send message')).toHaveCount(1, { timeout: 25000 });
 };

--- a/src/leapfrogai_ui/tests/helpers.ts
+++ b/src/leapfrogai_ui/tests/helpers.ts
@@ -28,5 +28,5 @@ export const deleteConversationsByLabel = async (labels: string[]) => {
 export const waitForResponseToComplete = async (page: Page) => {
 	await expect(page.getByLabel('cancel message')).toHaveCount(1, { timeout: 25000 });
 	await expect(page.getByLabel('cancel message')).toHaveCount(0, { timeout: 25000 });
-	await expect(page.getByLabel('send')).toHaveCount(1, { timeout: 25000 });
+	await expect(page.getByLabel('send message')).toHaveCount(1, { timeout: 25000 });
 };


### PR DESCRIPTION
Carbon applies the iconDescription as a tooltip for buttons that use icons. This label is attached as an aria-label to the svg component within the button, not the actual button. We need a test id to get the buttons for tests, while also ensuring the tooltips are not undefined for the user. I didn't want to put an aria-label on the button as well as the svg, so this solution fixes the tooltips while also ensuring tests pass.