### PR TITLE
chore: show copy/edit btns for non last message during regen

### DIFF
--- a/src/leapfrogai_ui/src/lib/components/Message.svelte
+++ b/src/leapfrogai_ui/src/lib/components/Message.svelte
@@ -120,6 +120,7 @@
 	}
 	.message {
 		display: flex;
+		white-space: pre-line;
 	}
 
 	.transparent {

--- a/src/leapfrogai_ui/src/lib/components/Message.svelte
+++ b/src/leapfrogai_ui/src/lib/components/Message.svelte
@@ -85,7 +85,7 @@
 						<span on:click={() => (editMode = true)}><Edit aria-label="edit prompt" /></span>
 					</div>
 				{/if}
-				{#if message.role !== 'user' && !isLoading}
+				{#if message.role !== 'user' && (isLastMessage ? !isLoading : true)}
 					<div data-testid="copy btn" class="highlight-icon" class:hide={!messageIsHovered}>
 						<span on:click={handleCopy}><Copy aria-label="copy message" /></span>
 					</div>

--- a/src/leapfrogai_ui/src/lib/components/Message.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/Message.test.ts
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/svelte';
-import { afterAll, afterEach, vi } from 'vitest';
+import {afterAll, afterEach, type MockInstance, vi} from 'vitest';
 import { Message } from '$components/index';
 import userEvent from '@testing-library/user-event';
 import { getFakeMessage } from '../../testUtils/fakeData';
@@ -66,7 +66,7 @@ describe('Message component', () => {
 	});
 
 	describe('util functions', () => {
-		let clipboardSpy;
+		let clipboardSpy: MockInstance;
 
 		afterAll(() => {
 			clipboardSpy.mockRestore();
@@ -164,6 +164,26 @@ describe('Message component', () => {
 			});
 			expect(screen.queryByLabelText('copy message')).not.toBeInTheDocument();
 			expect(screen.queryByLabelText('regenerate message')).not.toBeInTheDocument();
+		});
+		it('leaves the copy button for messages when it is loading if not the latest message', () => {
+			render(MessageWithToast, {
+				...defaultMessageProps,
+				message: getFakeMessage({ role: 'assistant' }),
+				isLastMessage: false,
+				isLoading: true
+			});
+			expect(screen.getByLabelText('copy message')).toBeInTheDocument();
+
+		});
+		it('leaves the edit button for messages when it is loading if not the latest message', () => {
+			render(MessageWithToast, {
+				...defaultMessageProps,
+				message: getFakeMessage({ role: 'user' }),
+				isLastMessage: false,
+				isLoading: true
+			});
+			expect(screen.getByRole('img', { name: /edit prompt/i })).toBeInTheDocument();
+
 		});
 	});
 });


### PR DESCRIPTION
Small change to show message edit/copy buttons when a message response is being streamed except for on the last message. Including @gregclark-defenseunicorns as approver this time as this change request was missed on PR that delivered this feature.