### PR TITLE
Add supabase to release workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,6 +5,7 @@ on:
       - ready_for_review
       - review_requested
       - synchronize
+      - milestoned
     paths:
       # Catch-all
       - "**"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,11 @@
 name: lint
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - ready_for_review
+      - review_requested
+      - synchronize
+      - milestoned
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,6 +1,11 @@
 name: pytest
 on:
   pull_request:
+    types:
+      - ready_for_review
+      - review_requested
+      - synchronize
+      - milestoned
     paths:
       - "**"
       - "!.github/**"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,14 @@ jobs:
           docker image prune -af
           rm zarf-package-leapfrogai-ui-*.tar.zst
 
+      - name: Build and Publish Supabase
+        run: |
+          zarf package create packages/supabase --set=IMAGE_VERSION=${{ steps.get_version.outputs.version-without-v }} --architecture amd64 --confirm
+          zarf package create packages/supabase --set=IMAGE_VERSION=${{ steps.get_version.outputs.version-without-v }} --architecture arm64 --confirm
+
+          zarf package publish zarf-package-supabase-amd64-${{ steps.get_version.outputs.version-without-v }}.tar.zst oci://ghcr.io/defenseunicorns/packages/leapfrogai
+          zarf package publish zarf-package-supabase-arm64-${{ steps.get_version.outputs.version-without-v }}.tar.zst oci://ghcr.io/defenseunicorns/packages/leapfrogai
+
       - name: Build and Publish repeater
         run: |
           docker buildx build --platform amd64,arm64 -t ghcr.io/defenseunicorns/leapfrogai/repeater:${{ steps.get_version.outputs.version-without-v }} --push packages/repeater


### PR DESCRIPTION
This PR adds supabase to the release workflow so that an amd64 and arm64 zarf package will be published whenever a tag is pushed to this repo.

This PR also adds `milestoned` as an event trigger to our workflows. This allows us to trigger workflows on PRs that don't normally trigger a workflow (such as when the author is  `github-actions`.