### PR TITLE
fix: allow release-please to update pyrpoject.toml files

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -30,6 +30,16 @@
           "type": "generic",
           "path": "**/uds-bundle.yaml",
           "glob": true
+        },
+        {
+          "type": "generic",
+          "path": "**/pyproject.toml",
+          "glob": true
+        },
+        {
+          "type": "generic",
+          "path": "**/zarf-config.yaml",
+          "glob": true
         }
       ]
     }

--- a/packages/llama-cpp-python/pyproject.toml
+++ b/packages/llama-cpp-python/pyproject.toml
@@ -3,7 +3,7 @@ name = "lfai-llama-cpp-python"
 description = "A LeapfrogAI API-compatible llama-cpp-python wrapper for quantized and un-quantized model inferencing on CPU infrastructures."
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/packages/repeater/pyproject.toml
+++ b/packages/repeater/pyproject.toml
@@ -3,7 +3,7 @@ name = "lfai-repeater"
 description = "A LeapfrogAI API-compatible pseudo-model for testing the API."
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/packages/repeater/zarf-config.yaml
+++ b/packages/repeater/zarf-config.yaml
@@ -3,7 +3,7 @@ package:
     set:
       image_repository: "ghcr.io/defenseunicorns/leapfrogai/repeater"
       # x-release-please-start-version
-      image_version: 0.6.1
+      image_version: 0.7.0
       # x-release-please-end
       name: repeater
     max_package_size: "1000000000"

--- a/packages/text-embeddings/pyproject.toml
+++ b/packages/text-embeddings/pyproject.toml
@@ -3,7 +3,7 @@ name = "lfai-text-embeddings"
 description = "A LeapfrogAI API-compatible embeddings library wrapper for text-based embedding generation."
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/packages/vllm/pyproject.toml
+++ b/packages/vllm/pyproject.toml
@@ -3,7 +3,7 @@ name = "lfai-vllm"
 description = "A LeapfrogAI API-compatible VLLM wrapper for quantized and un-quantized model inferencing across GPU infrastructures."
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/packages/whisper/pyproject.toml
+++ b/packages/whisper/pyproject.toml
@@ -3,7 +3,7 @@ name = "lfai-whisper"
 description = "A LeapfrogAI API-compatible faster-whisper wrapper for audio transcription generation across CPU and GPU infrastructures."
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/src/leapfrogai_api/pyproject.toml
+++ b/src/leapfrogai_api/pyproject.toml
@@ -3,7 +3,7 @@ name = "leapfrogai-api"
 description = "An API for LeapfrogAI that allows LeapfrogAI backends to connect seamlessly"
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [

--- a/src/leapfrogai_sdk/pyproject.toml
+++ b/src/leapfrogai_sdk/pyproject.toml
@@ -3,7 +3,7 @@ name = "leapfrogai-sdk"
 description = "A tool for building gRPC-based model backends for LeapfrogAI"
 
 # x-release-please-start-version
-version = "0.6.1"
+version = "0.7.0"
 # x-release-please-end
 
 dependencies = [


### PR DESCRIPTION
We neglected to include `pyproject.toml` files in the release-please instructions. This PR updates the instructions to ensure these files get updated automatically for future releases.

This PR also manually updates the version of the files that were lagging behind.