### PR TITLE
chore: Turn supabase domain into a templated value

### DIFF
--- a/packages/supabase/bitnami-values.yaml
+++ b/packages/supabase/bitnami-values.yaml
@@ -7,6 +7,10 @@ leapfrogai:
     component: kong
   sso:
     clientId: ###ZARF_CONST_EXTERNAL_KEYCLOAK_CLIENT_ID###
+    redirectUris:
+      - "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_HOSTED_DOMAIN###/auth/v1/callback"
+    webOrigins:
+      - "https://ai.###ZARF_VAR_HOSTED_DOMAIN###"
 
 global:
   jwt:
@@ -24,7 +28,7 @@ jwt:
     resourcesPreset: "none"
     podLabels:
       sidecar.istio.io/inject: "false"
-publicURL: "https://supabase-kong.uds.dev"
+publicURL: "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_HOSTED_DOMAIN###"
 auth:
   enabled: ###ZARF_VAR_ENABLE_AUTH###
   defaultConfig: |
@@ -53,8 +57,8 @@ auth:
     GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "{{ include "supabase.studio.publicURL" . }}/auth/v1/verify"
     GOTRUE_EXTERNAL_KEYCLOAK_ENABLED: "###ZARF_VAR_ENABLE_EXTERNAL_KEYCLOAK###"
     GOTRUE_EXTERNAL_KEYCLOAK_CLIENT_ID: "{{ .Values.leapfrogai.sso.clientId }}"
-    GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI: "###ZARF_CONST_EXTERNAL_KEYCLOAK_REDIRECT_URL###"
-    GOTRUE_EXTERNAL_KEYCLOAK_URL: "###ZARF_CONST_EXTERNAL_KEYCLOAK_URL###"
+    GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI: "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_HOSTED_DOMAIN###/auth/v1/callback"
+    GOTRUE_EXTERNAL_KEYCLOAK_URL: "https://keycloak.admin.###ZARF_VAR_HOSTED_DOMAIN###/realms/uds"
   image:
     tag: 2.149.0-debian-12-r0
   resourcesPreset: "none"
@@ -100,7 +104,7 @@ storage:
 
 studio:
   enabled: ###ZARF_VAR_ENABLE_STUDIO###
-  publicURL: "https://ai.uds.dev"
+  publicURL: "https://ai.###ZARF_VAR_HOSTED_DOMAIN###"
   image:
     tag: 0.24.3-debian-12-r0
   resourcesPreset: "none"

--- a/packages/supabase/chart/templates/uds-package.yaml
+++ b/packages/supabase/chart/templates/uds-package.yaml
@@ -8,9 +8,13 @@ spec:
       description: Client for logging into Supabase
       clientId: {{ .Values.leapfrogai.sso.clientId }}
       redirectUris:
-        - "https://supabase-kong.uds.dev/auth/v1/callback"
+        {{- range $.Values.leapfrogai.sso.redirectUris }}
+        - {{ tpl . $ }}
+        {{- end }}
       webOrigins:
-        - "https://ai.uds.dev/"
+        {{- range $.Values.leapfrogai.sso.webOrigins }}
+        - {{ tpl . $ }}
+        {{- end }}
   network:
     expose:
       - service: supabase-kong

--- a/packages/supabase/zarf.yaml
+++ b/packages/supabase/zarf.yaml
@@ -13,14 +13,10 @@ constants:
   - name: EXTERNAL_KEYCLOAK_CLIENT_ID
     description: 'External keycloak client value'
     value: "uds-supabase"
-  - name: EXTERNAL_KEYCLOAK_REDIRECT_URL
-    description: 'Keycloaks redirect url'
-    value: "https://supabase-kong.uds.dev/auth/v1/callback"
-  - name: EXTERNAL_KEYCLOAK_URL
-    description: 'External keycloak url'
-    value: "https://keycloak.admin.uds.dev/realms/uds"
 
 variables:
+  - name: HOSTED_DOMAIN
+    default: "uds.dev"
   - name: UI_SQL_SCHEMA
     type: file
     default: "migrations/20240322174521_ui_sql_schema.sql"

--- a/uds-bundles/dev/cpu/uds-bundle.yaml
+++ b/uds-bundles/dev/cpu/uds-bundle.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json
+
 kind: UDSBundle
 metadata:
   name: leapfrogai
@@ -34,6 +36,18 @@ packages:
   - name: supabase
     path: ../../../packages/supabase/
     ref: dev
+    overrides:
+      supabase:
+        supabase-secrets-generator:
+          variables:
+            - path: "leapfrogai.sso.redirectUris"
+              name: "KEYCLOAK_REDIRECT_URIS"
+              default:
+                - "https://supabase-kong.uds.dev/auth/v1/callback"
+            - path: "leapfrogai.sso.webOrigins"
+              name: KEYCLOAK_WEB_ORIGINS
+              default:
+                - "https://ai.uds.dev"
 
   # UI
   - name: leapfrogai-ui

--- a/uds-bundles/dev/cpu/uds-config.yaml
+++ b/uds-bundles/dev/cpu/uds-config.yaml
@@ -17,6 +17,13 @@ variables:
     embedding_model_name: text-embeddings
     top_k: 20
 
+  supabase:
+    keycloak_redirect_uris:
+      - "https://supabase-kong.uds.dev/auth/v1/callback"
+    webOrigins:
+      - "https://ai.uds.dev"
+    hosted_domain: "uds.dev"
+
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev

--- a/uds-bundles/dev/gpu/uds-bundle.yaml
+++ b/uds-bundles/dev/gpu/uds-bundle.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json
+
 kind: UDSBundle
 metadata:
   name: leapfrogai
@@ -34,6 +36,18 @@ packages:
   - name: supabase
     path: ../../../packages/supabase/
     ref: dev
+    overrides:
+      supabase:
+        supabase-secrets-generator:
+          variables:
+            - path: "leapfrogai.sso.redirectUris"
+              name: "KEYCLOAK_REDIRECT_URIS"
+              default:
+                - "https://supabase-kong.uds.dev/auth/v1/callback"
+            - path: "leapfrogai.sso.webOrigins"
+              name: KEYCLOAK_WEB_ORIGINS
+              default:
+                - "https://ai.uds.dev"
 
   # UI
   - name: leapfrogai-ui

--- a/uds-bundles/dev/gpu/uds-config.yaml
+++ b/uds-bundles/dev/gpu/uds-config.yaml
@@ -22,6 +22,13 @@ variables:
     embedding_model_name: text-embeddings
     top_k: 20
 
+  supabase:
+    keycloak_redirect_uris:
+      - "https://supabase-kong.uds.dev/auth/v1/callback"
+    webOrigins:
+      - "https://ai.uds.dev"
+    hosted_domain: "uds.dev"
+
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev

--- a/uds-bundles/latest/cpu/uds-bundle.yaml
+++ b/uds-bundles/latest/cpu/uds-bundle.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json
+
 kind: UDSBundle
 metadata:
   name: leapfrogai
@@ -46,6 +48,18 @@ packages:
     # x-release-please-start-version
     ref: 0.7.0
     # x-release-please-end
+    overrides:
+      supabase:
+        supabase-secrets-generator:
+          variables:
+            - path: "leapfrogai.sso.redirectUris"
+              name: "KEYCLOAK_REDIRECT_URIS"
+              default:
+                - "https://supabase-kong.uds.dev/auth/v1/callback"
+            - path: "leapfrogai.sso.webOrigins"
+              name: KEYCLOAK_WEB_ORIGINS
+              default:
+                - "https://ai.uds.dev"
 
   # UI - new UI TODO - point to ghcr image after Sprint 0.7.0
   - name: leapfrogai-ui

--- a/uds-bundles/latest/cpu/uds-config.yaml
+++ b/uds-bundles/latest/cpu/uds-config.yaml
@@ -17,6 +17,13 @@ variables:
     embedding_model_name: text-embeddings
     top_k: 20
 
+  supabase:
+    keycloak_redirect_uris:
+      - "https://supabase-kong.uds.dev/auth/v1/callback"
+    webOrigins:
+      - "https://ai.uds.dev"
+    hosted_domain: "uds.dev"
+
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev

--- a/uds-bundles/latest/gpu/uds-bundle.yaml
+++ b/uds-bundles/latest/gpu/uds-bundle.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/uds.schema.json
+
 kind: UDSBundle
 metadata:
   name: leapfrogai
@@ -46,6 +48,18 @@ packages:
     # x-release-please-start-version
     ref: 0.7.0
     # x-release-please-end
+    overrides:
+      supabase:
+        supabase-secrets-generator:
+          variables:
+            - path: "leapfrogai.sso.redirectUris"
+              name: "KEYCLOAK_REDIRECT_URIS"
+              default:
+                - "https://supabase-kong.uds.dev/auth/v1/callback"
+            - path: "leapfrogai.sso.webOrigins"
+              name: KEYCLOAK_WEB_ORIGINS
+              default:
+                - "https://ai.uds.dev"
 
   # UI - new UI TODO - point to ghcr image after Sprint 0.7.0
   - name: leapfrogai-ui

--- a/uds-bundles/latest/gpu/uds-config.yaml
+++ b/uds-bundles/latest/gpu/uds-config.yaml
@@ -22,6 +22,13 @@ variables:
     embedding_model_name: text-embeddings
     top_k: 20
 
+  supabase:
+    keycloak_redirect_uris:
+      - "https://supabase-kong.uds.dev/auth/v1/callback"
+    webOrigins:
+      - "https://ai.uds.dev"
+    hosted_domain: "uds.dev"
+
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev


### PR DESCRIPTION
This PR turns the domain that supabase serves itself on (and access for other operations) into a value that can be templated and set during deploy time.

The old value was hardcoded to `uds.dev` which always redirects to localhost. This value being hardcode meant that deployments would work on your local machines (or when you could modify your `/etc/hosts` files, but would not work when trying to deploy to a different environment behind a different hostname. Now that the values are templates, deployers of the package have more flexibility over which environments they deploy to.