### PR TITLE
chore: group 'minor' and 'patch' level npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: '/src/leapfrogai_ui' # Location of package manifests
     schedule:
       interval: 'weekly'
+    groups:
+      non-major-dev-updates:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Instead of having three+ PRs failing workflow, now we only need to have one!