### PR TITLE
Add UI Playwright Tests to E2E Workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,6 +61,14 @@ jobs:
         - name: Install Python Deps
           run: python -m pip install "."
 
+        - name: Setup Node
+          uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with:
+            node-version-file: 'src/leapfrogai_ui/package.json'
+
+        - name: Install UI Dependencies
+          run: npm --prefix src/leapfrogai_ui ci
+
         - name: Setup UDS Environment
           uses: defenseunicorns/uds-common/.github/actions/setup@05f42bb3117b66ebef8c72ae050b34bce19385f5
           with:
@@ -92,7 +100,26 @@ jobs:
             python -m pip install requests
             python -m pytest ./tests/e2e/test_supabase.py -v
 
-        # This cleanup may need to be moved/removed when other packages depend on Supabase
+        ##########
+        # UI
+        ##########
+        - name: Deploy LFAI-UI
+          run: |
+            make build-ui LOCAL_VERSION=e2e-test
+            docker image prune -af
+            uds zarf package deploy packages/ui/zarf-package-leapfrogai-ui-amd64-e2e-test.tar.zst --confirm
+            rm packages/api/zarf-package-leapfrogai-api-amd64-e2e-test.tar.zst
+
+        # Run the playwright UI tests using the deployed Supabase endpoint
+        - name: UI and Supabase test
+          run: |
+            TEST_ENV=e2e PUBLIC_SUPABASE_URL=http://supabase-kong.uds.dev PUBLIC_SUPABASE_ANON_KEY=$API_KEY npm --prefix src/leapfrogai_ui run test:integration
+
+        - name: Cleanup UI
+          run: |
+            uds zarf package remove leapfrogai-ui --confirm
+
+        # Supabase can now be removed since we're done testing it
         - name: Cleanup Supabase
           run: |
             uds zarf package remove supabase -l=trace --confirm

--- a/src/leapfrogai_ui/playwright.config.ts
+++ b/src/leapfrogai_ui/playwright.config.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const config: PlaywrightTestConfig = {
+const defaultConfig: PlaywrightTestConfig = {
   projects: [
     { name: 'setup', testMatch: /.*\.setup\.ts/ },
     { name: 'clear_db', testMatch: /.*\clear_db\.ts/ },
@@ -41,13 +41,36 @@ const config: PlaywrightTestConfig = {
       dependencies: ['clear_db', 'setup']
     }
   ],
+  testDir: 'tests',
+  testMatch: /(.+\.)?(test|spec)\.[jt]s/
+};
+
+// when in dev, create a local webserver
+const devConfig: PlaywrightTestConfig = {
   webServer: {
     command: 'npm run build && npm run preview',
     port: 4173,
     stderr: 'pipe'
   },
-  testDir: 'tests',
-  testMatch: /(.+\.)?(test|spec)\.[jt]s/
+  use: {
+    baseURL: 'http://localhost:4173'
+  }
+};
+
+// when e2e testing, use the deployed instance
+const e2eConfig: PlaywrightTestConfig = {
+  use: {
+    baseURL: 'http://ai.uds.dev'
+  }
+};
+
+// get the environment type from command line. If none, set it to dev
+const environment = process.env.TEST_ENV || 'dev';
+
+// config object with default configuration and environment specific configuration
+const config: PlaywrightTestConfig = {
+  ...defaultConfig,
+  ...(environment === 'e2e' ? e2eConfig : devConfig)
 };
 
 export default config;

--- a/src/leapfrogai_ui/tests/auth.setup.ts
+++ b/src/leapfrogai_ui/tests/auth.setup.ts
@@ -5,7 +5,7 @@ import * as OTPAuth from 'otpauth';
 setup('authenticate', async ({ page, clearDbData }) => {
   await clearDbData();
 
-  await page.goto('http://localhost:4173');
+  await page.goto('/'); // go to the home page
   if (process.env.PUBLIC_DISABLE_KEYCLOAK === 'true') {
     // uses local supabase test users, logs in directly with Supabase, no Keycloak
     await page.getByText('Already have an account? Sign In').click();
@@ -46,7 +46,7 @@ setup('authenticate', async ({ page, clearDbData }) => {
   //
   // Login flow sets cookies in the process of several redirects.
   // Wait for the final URL to ensure that the cookies are actually set.
-  await page.waitForURL('http://localhost:4173/chat');
+  await page.waitForURL('/chat');
 
   // Alternatively, you can wait until the page reaches a state where all cookies are set.
   //   await expect(page.getByRole('button', { name: 'View profile and more' })).toBeVisible();


### PR DESCRIPTION
- Adds the UI Zarf Package deployment to the e2e workflow
- Calls the UI Playwright tests, using the UI as the test instance and the deployed Supabase package as the database backend