### PR TITLE
539 UI enhancements

### DIFF
--- a/src/leapfrogai_ui/src/lib/components/ChatSidebar.svelte
+++ b/src/leapfrogai_ui/src/lib/components/ChatSidebar.svelte
@@ -302,7 +302,6 @@ https://github.com/carbon-design-system/carbon-components-svelte/issues/892
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    padding: 0 0 layout.$spacing-05 0;
 
     :global(.bx--side-nav__divider) {
       margin: layout.$spacing-03 0 0 0;

--- a/src/leapfrogai_ui/src/lib/components/ChatSidebar.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/ChatSidebar.test.ts
@@ -64,7 +64,8 @@ vi.mock('$app/stores', (): typeof stores => {
 describe('ChatSidebar', () => {
   it('renders threads', async () => {
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -86,7 +87,8 @@ describe('ChatSidebar', () => {
     });
 
     threadsStore.set({
-      threads: [fakeTodayThread, fakeYesterdayThread] // uses date override starting in March
+      threads: [fakeTodayThread, fakeYesterdayThread], // uses date override starting in March
+      lastVisitedThreadId: ''
     });
 
     render(ChatSidebar);
@@ -108,7 +110,8 @@ describe('ChatSidebar', () => {
     mockDeleteThread();
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -143,7 +146,8 @@ describe('ChatSidebar', () => {
     const toastSpy = vi.spyOn(toastStore, 'addToast');
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -174,7 +178,8 @@ describe('ChatSidebar', () => {
     mockEditThreadLabel();
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -192,7 +197,8 @@ describe('ChatSidebar', () => {
     mockEditThreadLabel();
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -210,7 +216,8 @@ describe('ChatSidebar', () => {
     mockEditThreadLabel();
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -239,7 +246,8 @@ describe('ChatSidebar', () => {
 
     const newLabelText = 'new label';
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -257,7 +265,8 @@ describe('ChatSidebar', () => {
   it('does not update the thread label when the user presses escape and it removes the text input', async () => {
     const newLabelText = 'new label';
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -277,7 +286,8 @@ describe('ChatSidebar', () => {
     mockEditThreadLabel();
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -299,7 +309,8 @@ describe('ChatSidebar', () => {
     const newLabelText = 'new label';
 
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -314,7 +325,8 @@ describe('ChatSidebar', () => {
     const fakeThread = getFakeThread({ numMessages: 6 });
 
     threadsStore.set({
-      threads: [fakeThread]
+      threads: [fakeThread],
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatSidebar);
@@ -332,7 +344,8 @@ describe('ChatSidebar', () => {
     const fakeThread3 = getFakeThread({ numMessages: 2 });
 
     threadsStore.set({
-      threads: [fakeThread1, fakeThread2, fakeThread3]
+      threads: [fakeThread1, fakeThread2, fakeThread3],
+      lastVisitedThreadId: ''
     });
 
     render(ChatSidebar);
@@ -355,7 +368,8 @@ describe('ChatSidebar', () => {
     const fakeThread3 = getFakeThread({ numMessages: 2 });
 
     threadsStore.set({
-      threads: [fakeThread1, fakeThread2, fakeThread3]
+      threads: [fakeThread1, fakeThread2, fakeThread3],
+      lastVisitedThreadId: ''
     });
 
     render(ChatSidebar);

--- a/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
+++ b/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
@@ -82,7 +82,7 @@
     icon={Export}
     size="small"
     iconDescription="Export conversations"
-    on:click={onExport}>Export Chat History</Button
+    on:click={onExport}>Export chat history</Button
   >
 </div>
 

--- a/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
+++ b/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
@@ -80,8 +80,9 @@
     id="export-btn"
     kind="ghost"
     icon={Export}
+    size="small"
     iconDescription="Export conversations"
-    on:click={onExport}>Export data</Button
+    on:click={onExport}>Export Chat History</Button
   >
 </div>
 
@@ -90,6 +91,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    padding: layout.$spacing-03 0 layout.$spacing-03 0;
     :global(.bx--btn) {
       width: 100%;
       color: themes.$text-secondary;

--- a/src/leapfrogai_ui/src/lib/components/ImportExport.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/ImportExport.test.ts
@@ -67,7 +67,7 @@ describe('Import and Export chat history', () => {
 
     render(ImportExport);
 
-    await userEvent.click(screen.getByText('Export Chat History'));
+    await userEvent.click(screen.getByText('Export chat history'));
     expect(toastSpy).toHaveBeenCalledTimes(1);
     expect(toastSpy).toHaveBeenCalledWith({
       kind: 'error',

--- a/src/leapfrogai_ui/src/lib/components/ImportExport.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/ImportExport.test.ts
@@ -12,12 +12,12 @@ const uploadJSONFile = async (obj: object) => {
   const blob = new Blob([dataStr]);
   const file = new File([blob], 'badData.json', { type: 'application/JSON' });
   File.prototype.text = vi.fn().mockResolvedValueOnce(dataStr);
-  const uploadBtn = screen.getByTestId('import data input');
+  const uploadBtn = screen.getByTestId('import-chat-history-input');
 
   await userEvent.upload(uploadBtn, file);
 };
 
-describe('Import and Export data', () => {
+describe('Import and Export chat history', () => {
   // Note - actual exporting and importing of data tested with E2E test
 
   afterEach(() => {
@@ -67,7 +67,7 @@ describe('Import and Export data', () => {
 
     render(ImportExport);
 
-    await userEvent.click(screen.getByText('Export data'));
+    await userEvent.click(screen.getByText('Export Chat History'));
     expect(toastSpy).toHaveBeenCalledTimes(1);
     expect(toastSpy).toHaveBeenCalledWith({
       kind: 'error',
@@ -78,7 +78,7 @@ describe('Import and Export data', () => {
 
   it('only allows uploading of JSON files', async () => {
     render(ImportExport);
-    const uploadBtn = screen.getByTestId('import data input');
+    const uploadBtn = screen.getByTestId('import-chat-history-input');
 
     expect(uploadBtn).toHaveAttribute('accept', 'application/json');
   });

--- a/src/leapfrogai_ui/src/lib/components/LFFileUploader.svelte
+++ b/src/leapfrogai_ui/src/lib/components/LFFileUploader.svelte
@@ -43,6 +43,6 @@
     size="small"
     icon={Download}
     iconDescription="Import conversations"
-    on:click={() => ref?.click()}>Import Chat History</Button
+    on:click={() => ref?.click()}>Import chat history</Button
   >
 </div>

--- a/src/leapfrogai_ui/src/lib/components/LFFileUploader.svelte
+++ b/src/leapfrogai_ui/src/lib/components/LFFileUploader.svelte
@@ -20,7 +20,7 @@
 
 <div>
   <input
-    data-testid="import data input"
+    data-testid="import-chat-history-input"
     id="import-conversations"
     bind:this={ref}
     type="file"
@@ -40,8 +40,9 @@
     id="import-btn"
     kind="ghost"
     disabled={importing}
+    size="small"
     icon={Download}
     iconDescription="Import conversations"
-    on:click={() => ref?.click()}>Import data</Button
+    on:click={() => ref?.click()}>Import Chat History</Button
   >
 </div>

--- a/src/leapfrogai_ui/src/lib/components/LFHeader.svelte
+++ b/src/leapfrogai_ui/src/lib/components/LFHeader.svelte
@@ -3,6 +3,7 @@
   import logo from '$assets/LeapfrogAI.png';
   import { Settings, UserAvatar } from 'carbon-icons-svelte';
   import { Header, HeaderAction, HeaderUtilities } from 'carbon-components-svelte';
+  import { threadsStore } from '$stores';
 
   let loading = false;
   let signOutForm: HTMLFormElement;
@@ -36,7 +37,14 @@
   persistentHamburgerMenu={innerWidth ? innerWidth < 1056 : false}
   bind:isSideNavOpen={$uiStore.isSideNavOpen}
 >
-  <span slot="platform"><img alt="LeapfrogAI Logo" src={logo} class="logo" /></span>
+  <span slot="platform"
+    ><a
+      data-testid="header-logo-link"
+      href={$threadsStore.lastVisitedThreadId
+        ? `/chat/${$threadsStore.lastVisitedThreadId}`
+        : '/chat'}><img alt="LeapfrogAI Logo" src={logo} class="logo" /></a
+    ></span
+  >
   <HeaderUtilities>
     <HeaderAction
       data-testid="settings header action button"

--- a/src/leapfrogai_ui/src/lib/components/LFHeader.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/LFHeader.test.ts
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/svelte';
 import { LFHeader } from '$components/index';
 import userEvent from '@testing-library/user-event';
+import { threadsStore } from '$stores';
+import { getFakeThread } from '$testUtils/fakeData';
 
 describe('LFHeader', () => {
   it('closes the other header actions when one is opened', async () => {
@@ -19,5 +21,17 @@ describe('LFHeader', () => {
 
     expect(settingsActionBtn).toHaveClass('bx--header__action--active');
     expect(userActionBtn).not.toHaveClass('bx--header__action--active');
+  });
+  it('has a link on the logo that navigates to the last visited thread id', () => {
+    const thread = getFakeThread();
+
+    threadsStore.set({
+      threads: [thread],
+      lastVisitedThreadId: thread.id
+    });
+    render(LFHeader);
+    expect(
+      screen.getByTestId('header-logo-link')
+    ).toHaveAttribute('href', `/chat/${thread.id}`);
   });
 });

--- a/src/leapfrogai_ui/src/lib/components/LFHeader.test.ts
+++ b/src/leapfrogai_ui/src/lib/components/LFHeader.test.ts
@@ -30,8 +30,6 @@ describe('LFHeader', () => {
       lastVisitedThreadId: thread.id
     });
     render(LFHeader);
-    expect(
-      screen.getByTestId('header-logo-link')
-    ).toHaveAttribute('href', `/chat/${thread.id}`);
+    expect(screen.getByTestId('header-logo-link')).toHaveAttribute('href', `/chat/${thread.id}`);
   });
 });

--- a/src/leapfrogai_ui/src/lib/stores/threads.ts
+++ b/src/leapfrogai_ui/src/lib/stores/threads.ts
@@ -9,10 +9,12 @@ import { getMessageText } from '$helpers/threads';
 
 type ThreadsStore = {
   threads: LFThread[];
+  lastVisitedThreadId: string;
 };
 
 const defaultValues: ThreadsStore = {
-  threads: []
+  threads: [],
+  lastVisitedThreadId: ''
 };
 
 const createThread = async (input: NewThreadInput) => {
@@ -95,6 +97,9 @@ const createThreadsStore = () => {
     update,
     setThreads: (threads: LFThread[]) => {
       update((old) => ({ ...old, threads }));
+    },
+    setLastVisitedThreadId: (id: string) => {
+      update((old) => ({ ...old, lastVisitedThreadId: id }));
     },
     changeThread: async (newId: string | null) => {
       await goto(`/chat/${newId}`);

--- a/src/leapfrogai_ui/src/lib/stores/threads.ts
+++ b/src/leapfrogai_ui/src/lib/stores/threads.ts
@@ -111,6 +111,7 @@ const createThreadsStore = () => {
         });
         if (newThread) {
           newThread.messages = [];
+
           update((old) => {
             return {
               ...old,
@@ -163,6 +164,7 @@ const createThreadsStore = () => {
           ...old,
           threads: old.threads.filter((c) => c.id !== id)
         }));
+        await goto(`/chat`);
       } catch {
         toastStore.addToast({
           kind: 'error',

--- a/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
+++ b/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
@@ -19,6 +19,7 @@
 
   $: activeThread = $threadsStore.threads.find((thread) => thread.id === $page.params.thread_id);
 
+  $: $page.params.thread_id, threadsStore.setLastVisitedThreadId($page.params.thread_id);
   $: $page.params.thread_id,
     setMessages(activeThread?.messages?.map((m) => convertMessageToAiMessage(m)) || []);
 

--- a/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
+++ b/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { LFTextArea, PoweredByDU } from '$components';
   import { Button } from 'carbon-components-svelte';
-  import { afterUpdate, onMount, tick } from 'svelte';
+  import { afterUpdate, tick } from 'svelte';
   import { threadsStore, toastStore } from '$stores';
   import { ArrowRight, StopFilledAlt } from 'carbon-icons-svelte';
   import { type Message as AIMessage, useChat } from 'ai/svelte';
@@ -10,8 +10,6 @@
   import Message from '$components/Message.svelte';
   import type { LFMessage } from '$lib/types/messages';
   import { convertMessageToAiMessage, getMessageText } from '$helpers/threads';
-
-  export let data;
 
   let messageThreadDiv: HTMLDivElement;
 
@@ -139,10 +137,6 @@
     setMessages($messages.toSpliced(messageIndex, 1));
     await reload();
   };
-
-  onMount(() => {
-    threadsStore.setThreads(data.threads || []);
-  });
 
   afterUpdate(() => {
     // Scroll to bottom

--- a/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/chatpage.test.ts
+++ b/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/chatpage.test.ts
@@ -40,7 +40,8 @@ describe('The Chat Page', () => {
 
   it('it renders all the messages', async () => {
     threadsStore.set({
-      threads: fakeThreads
+      threads: fakeThreads,
+      lastVisitedThreadId: fakeThreads[0].id
     });
 
     render(ChatPage);
@@ -72,7 +73,8 @@ describe('The Chat Page', () => {
       mockNewMessage(fakeMessage);
 
       threadsStore.set({
-        threads: []
+        threads: [],
+        lastVisitedThreadId: ''
       });
 
       const user = userEvent.setup();
@@ -97,7 +99,8 @@ describe('The Chat Page', () => {
       mockNewMessage(fakeMessage);
 
       threadsStore.set({
-        threads: []
+        threads: [],
+        lastVisitedThreadId: ''
       });
 
       const user = userEvent.setup();
@@ -147,7 +150,8 @@ describe('The Chat Page', () => {
 
     it('displays an error message when there is an error saving the new thread', async () => {
       threadsStore.set({
-        threads: []
+        threads: [],
+        lastVisitedThreadId: ''
       });
 
       mockChatCompletion();
@@ -197,7 +201,8 @@ describe('The Chat Page', () => {
 
       it('displays an error message when there is an error saving the response', async () => {
         threadsStore.set({
-          threads: fakeThreads
+          threads: fakeThreads,
+          lastVisitedThreadId: fakeThreads[0].id
         });
 
         mockChatCompletion();
@@ -255,7 +260,8 @@ describe('The Chat Page', () => {
         mockNewMessage(fakeMessage);
 
         threadsStore.set({
-          threads: [fakeThreads[0]]
+          threads: [fakeThreads[0]],
+          lastVisitedThreadId: ''
         });
         const user = userEvent.setup();
 

--- a/src/leapfrogai_ui/src/routes/chat/(settings)/assistants-management/+layout.svelte
+++ b/src/leapfrogai_ui/src/routes/chat/(settings)/assistants-management/+layout.svelte
@@ -2,6 +2,7 @@
   import { Breadcrumb, BreadcrumbItem, Content } from 'carbon-components-svelte';
   import { page } from '$app/stores';
   import { PoweredByDU } from '$components';
+  import { threadsStore } from '$stores';
 
   const paths = [
     {
@@ -27,6 +28,14 @@
     // Handle edit route with assistant id as path parameter
     ($page.url.pathname.startsWith('/chat/assistants-management/edit/') &&
       path === '/chat/assistants-management/edit');
+
+  const getPath = (path: string) => {
+    if (path === '/chat')
+      return $threadsStore.lastVisitedThreadId
+        ? `/chat/${$threadsStore.lastVisitedThreadId}`
+        : '/chat';
+    return path;
+  };
 </script>
 
 <Content>
@@ -36,7 +45,7 @@
         {#each paths as { path, name } (path)}
           {#if $page.url.pathname.includes(path)}
             <BreadcrumbItem
-              href={isCurrentPage(path) ? '' : path}
+              href={isCurrentPage(path) ? '' : getPath(path)}
               isCurrentPage={isCurrentPage(path)}>{name}</BreadcrumbItem
             >
           {/if}

--- a/src/leapfrogai_ui/src/routes/chat/(settings)/assistants-management/assistants-management-page.test.ts
+++ b/src/leapfrogai_ui/src/routes/chat/(settings)/assistants-management/assistants-management-page.test.ts
@@ -3,6 +3,8 @@ import AssistantsManagementPage from './+page.svelte';
 import { getFakeAssistant } from '$testUtils/fakeData';
 
 describe('Assistants management page', () => {
+  // Assistant search tested with e2e
+
   it('displays all the assistants', async () => {
     const assistant1 = getFakeAssistant();
     const assistant2 = getFakeAssistant();
@@ -12,5 +14,4 @@ describe('Assistants management page', () => {
     screen.getByTestId(`assistant-tile-${assistant1.name!}`);
     screen.getByTestId(`assistant-tile-${assistant2.name!}`);
   });
-  // Assistant search tested with e2e
 });

--- a/src/leapfrogai_ui/src/routes/chat/(settings)/file-management/+layout.svelte
+++ b/src/leapfrogai_ui/src/routes/chat/(settings)/file-management/+layout.svelte
@@ -2,6 +2,7 @@
   import { Breadcrumb, BreadcrumbItem, Content } from 'carbon-components-svelte';
   import { page } from '$app/stores';
   import { PoweredByDU } from '$components';
+  import { threadsStore } from '$stores';
 
   const paths = [
     {
@@ -14,6 +15,14 @@
     }
   ];
   $: isCurrentPage = (path: string) => $page.url.pathname === path;
+
+  const getPath = (path: string) => {
+    if (path === '/chat')
+      return $threadsStore.lastVisitedThreadId
+        ? `/chat/${$threadsStore.lastVisitedThreadId}`
+        : '/chat';
+    return path;
+  };
 </script>
 
 <Content>
@@ -22,9 +31,8 @@
       <Breadcrumb noTrailingSlash>
         {#each paths as { path, name } (path)}
           {#if $page.url.pathname.includes(path)}
-            <BreadcrumbItem
-              href={isCurrentPage(path) ? '' : path}
-              isCurrentPage={isCurrentPage(path)}>{name}</BreadcrumbItem
+            <BreadcrumbItem href={getPath(path)} isCurrentPage={isCurrentPage(path)}
+              >{name}</BreadcrumbItem
             >
           {/if}
         {/each}

--- a/src/leapfrogai_ui/src/routes/chat/(settings)/file-management/file-management.test.ts
+++ b/src/leapfrogai_ui/src/routes/chat/(settings)/file-management/file-management.test.ts
@@ -4,7 +4,6 @@ import { getFakeFiles } from '../../../../../testUtils/fakeData';
 import userEvent from '@testing-library/user-event';
 import { formatDate } from '$helpers/dates';
 import { load } from './+page';
-import { sessionMock } from '$lib/mocks/supabase-mocks';
 import { mockDeleteFile, mockDeleteFileWithDelay, mockGetFiles } from '$lib/mocks/file-mocks';
 import { vi } from 'vitest';
 import { toastStore } from '$stores';
@@ -14,7 +13,7 @@ describe('file management', () => {
     const files = getFakeFiles();
     mockGetFiles(files);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
     render(FileManagementPage, { data });
 
     files.forEach((file) => {
@@ -25,7 +24,7 @@ describe('file management', () => {
     const files = getFakeFiles();
     mockGetFiles(files);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
     render(FileManagementPage, { data });
 
     expect(screen.getByText(files[1].filename)).toBeInTheDocument();
@@ -46,7 +45,7 @@ describe('file management', () => {
 
     mockGetFiles([file1, file2]);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
 
     render(FileManagementPage, { data });
 
@@ -65,7 +64,7 @@ describe('file management', () => {
     const files = getFakeFiles();
     mockGetFiles(files);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
     render(FileManagementPage, { data });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -91,7 +90,7 @@ describe('file management', () => {
     const files = getFakeFiles();
     mockGetFiles(files);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
     render(FileManagementPage, { data });
 
     const deleteBtn = screen.getByRole('button', { name: /delete/i });
@@ -102,7 +101,7 @@ describe('file management', () => {
     const files = getFakeFiles();
     mockGetFiles(files);
 
-    const data = await load({ fetch: global.fetch, locals: { safeGetSession: sessionMock } });
+    const data = await load({ fetch: global.fetch });
     render(FileManagementPage, { data });
 
     const deleteBtn = screen.getByRole('button', { name: /delete/i });

--- a/src/leapfrogai_ui/src/routes/chat/+layout.server.ts
+++ b/src/leapfrogai_ui/src/routes/chat/+layout.server.ts
@@ -4,7 +4,9 @@ import type { LFThread } from '$lib/types/threads';
 import { openai } from '$lib/server/constants';
 import type { LFMessage } from '$lib/types/messages';
 
-export const load = async ({ locals: { supabase, safeGetSession } }) => {
+export const load = async ({ depends, locals: { supabase, safeGetSession } }) => {
+  depends('lf:threads');
+  console.log('fetching threads in layout');
   const { session } = await safeGetSession();
 
   if (!session) {

--- a/src/leapfrogai_ui/src/routes/chat/+layout.ts
+++ b/src/leapfrogai_ui/src/routes/chat/+layout.ts
@@ -1,0 +1,12 @@
+import { browser } from '$app/environment';
+import { threadsStore } from '$stores';
+
+// Load the store with the threads fetched by the +layout.server.ts (set store on the client side only)
+// This only runs when the app is first loaded (because it's a higher level layout)
+// After this load, the app keeps the store in sync with data changes and we don't
+// re-fetch all that data from the server
+export const load = async ({ data }) => {
+  if (browser) {
+    threadsStore.setThreads(data.threads || []);
+  }
+};

--- a/src/leapfrogai_ui/tests/assistants.test.ts
+++ b/src/leapfrogai_ui/tests/assistants.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from './fixtures';
-import { createAssistant, deleteAllAssistants, loadChatPage } from './helpers';
+import {
+  createAssistant,
+  deleteAllAssistants,
+  getSimpleMathQuestion,
+  loadChatPage,
+  sendMessage
+} from './helpers';
 import { getFakeAssistantInput } from '../testUtils/fakeData';
 import type { ActionResult } from '@sveltejs/kit';
 
@@ -133,14 +139,24 @@ test('it can search for assistants', async ({ page, browserName }) => {
   }
 });
 
-test('it can navigate with breadcrumbs', async ({ page }) => {
-  await page.goto('/chat/assistants-management');
+test('it can navigate to the last visited thread with breadcrumbs', async ({ page }) => {
+  const newMessage = getSimpleMathQuestion();
+  await page.goto('/chat');
+  await sendMessage(page, newMessage);
+  const messages = page.getByTestId('message');
+  await expect(messages).toHaveCount(2);
+
+  const urlParts = new URL(page.url()).pathname.split('/');
+  const threadId = urlParts[urlParts.length - 1];
+
+  await page.getByLabel('Settings').click();
+  await page.getByText('Assistants Management').click();
   await page.getByRole('button', { name: 'New Assistant' }).click();
   await page.waitForURL('/chat/assistants-management/new');
   await page.getByRole('link', { name: 'Assistants Management' }).click();
   await page.waitForURL('/chat/assistants-management');
   await page.getByRole('link', { name: 'Chat' }).click();
-  await page.waitForURL('/chat');
+  await page.waitForURL(`/chat/${threadId}`);
 });
 
 test('it validates input', async ({ page }) => {

--- a/src/leapfrogai_ui/tests/file-management.test.ts
+++ b/src/leapfrogai_ui/tests/file-management.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures';
-import { loadChatPage } from './helpers';
+import {getSimpleMathQuestion, loadChatPage, sendMessage} from './helpers';
 import type { Page } from '@playwright/test';
 
 const loadFileManagementPage = async (page: Page) => {
@@ -45,6 +45,21 @@ test.beforeEach(async ({ page }) => {
   await page.reload();
 
   console.log('After Each completed');
+});
+
+test('it can navigate to the last visited thread with breadcrumbs', async ({ page }) => {
+  const newMessage = getSimpleMathQuestion();
+  await page.goto('/chat');
+  await sendMessage(page, newMessage);
+  const messages = page.getByTestId('message');
+  await expect(messages).toHaveCount(2);
+
+  const urlParts = new URL(page.url()).pathname.split('/');
+  const threadId = urlParts[urlParts.length - 1];
+
+  await page.goto('/chat/file-management');
+  await page.getByRole('link', { name: 'Chat' }).click();
+  await page.waitForURL(`/chat/${threadId}`);
 });
 
 test('it can navigate to the file management page', async ({ page }) => {

--- a/src/leapfrogai_ui/tests/file-management.test.ts
+++ b/src/leapfrogai_ui/tests/file-management.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures';
-import {getSimpleMathQuestion, loadChatPage, sendMessage} from './helpers';
+import { getSimpleMathQuestion, loadChatPage, sendMessage } from './helpers';
 import type { Page } from '@playwright/test';
 
 const loadFileManagementPage = async (page: Page) => {

--- a/src/leapfrogai_ui/tests/import_export.test.ts
+++ b/src/leapfrogai_ui/tests/import_export.test.ts
@@ -17,7 +17,7 @@ test('it can import and exports threads', async ({ page }) => {
   await expect(page.getByText(thread.metadata.label)).toHaveCount(1);
 
   const downloadPromise = page.waitForEvent('download');
-  await page.getByText('Export Chat History').click();
+  await page.getByText('Export chat history').click();
 
   const download = await downloadPromise;
 

--- a/src/leapfrogai_ui/tests/import_export.test.ts
+++ b/src/leapfrogai_ui/tests/import_export.test.ts
@@ -17,7 +17,7 @@ test('it can import and exports threads', async ({ page }) => {
   await expect(page.getByText(thread.metadata.label)).toHaveCount(1);
 
   const downloadPromise = page.waitForEvent('download');
-  await page.getByText('Export data').click();
+  await page.getByText('Export Chat History').click();
 
   const download = await downloadPromise;
 


### PR DESCRIPTION
closes #539 

- Add chat link to LF logo that links back to last viewed chat thread (breadcrumbs also link back to last thread)
- Update import/export text
- Remove excess padding in sidebar
- A few test typescript cleanups
- Fixes bug where thread messages wouldn't show without a page refresh when using in app navigation