### PR TITLE
chore(tests): Resolve e2e pytest discovery errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,3 +169,6 @@ build-cpu: build-supabase build-api build-ui build-llama-cpp-python build-text-e
 build-gpu: build-supabase build-api build-ui build-vllm build-text-embeddings build-whisper ## Build all zarf packages for a gpu-enabled deployment of LFAI
 
 build-all: build-cpu build-gpu ## Build all of the LFAI packages
+
+include make-tests.mk
+include make-supabase.mk

--- a/make-supabase.mk
+++ b/make-supabase.mk
@@ -1,0 +1,28 @@
+SHELL := /bin/bash
+
+
+export SUPABASE_URL=$(shell cd src/leapfrogai_api; supabase status | grep -oP '(?<=API URL: ).*')
+export SUPABASE_ANON_KEY=$(shell cd src/leapfrogai_api; supabase status | grep -oP '(?<=anon key: ).*')
+
+define get_jwt_token
+	echo "Getting JWT token from ${SUPABASE_URL}..."; \
+	TOKEN_RESPONSE=$$(curl -s -X POST $(1) \
+	-H "apikey: ${SUPABASE_ANON_KEY}" \
+	-H "Content-Type: application/json" \
+	-d '{ "email": "admin@localhost", "password": "$$SUPABASE_PASS"}'); \
+	echo "Extracting token from $(TOKEN_RESPONSE)"; \
+	JWT=$$(echo $$TOKEN_RESPONSE | grep -oP '(?<="access_token":")[^"]*'); \
+	echo "SUPABASE_USER_JWT=$$JWT" > .env; \
+	echo "SUPABASE_URL=$$SUPABASE_URL" >> .env; \
+	echo "SUPABASE_ANON_KEY=$$SUPABASE_ANON_KEY" >> .env; \
+	echo "DONE - `.env` file updated"
+endef
+
+supabase-new-user:
+	@read -s -p "Enter a new DEV API password: " SUPABASE_PASS; echo; \
+	echo "Creating new supabase user..."; \
+	$(call get_jwt_token,"${SUPABASE_URL}/auth/v1/signup")
+
+env:
+	@read -s -p "Enter your DEV API password: " SUPABASE_PASS; echo; \
+	$(call get_jwt_token,"${SUPABASE_URL}/auth/v1/token?grant_type=password")

--- a/make-tests.mk
+++ b/make-tests.mk
@@ -1,0 +1,8 @@
+test-api-integration:
+	pytest tests/integration/api
+
+test-unit:
+	PYTHONPATH=$$(pwd) pytest tests/unit
+
+test-e2e:
+	pytest tests/e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [  # Dev dependencies needed for all of lfai
     "pytest",
     "httpx",
     "ruff",
-    "dotenv"
+    "python-dotenv"
 ]
 requires-python = "~=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [  # Dev dependencies needed for all of lfai
     "pytest",
     "httpx",
     "ruff",
+    "dotenv"
 ]
 requires-python = "~=3.11"
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,5 @@
 import json
 import os
-from dotenv import load_dotenv
 
 from openai import OpenAI
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,14 +1,24 @@
 import json
 import os
+from dotenv import load_dotenv
+
+from openai import OpenAI
 
 import pytest
 import requests
 
 # This is the anon_key for supabase, it provides access to the endpoints that would otherwise be inaccessible
-ANON_KEY = os.environ["ANON_KEY"]
+ANON_KEY = os.environ.get("ANON_KEY", "mock-data")
 
 DEFAULT_TEST_EMAIL = "fakeuser1@test.com"
 DEFAULT_TEST_PASSWORD = "password"
+
+
+@pytest.fixture(scope="module")
+def client():
+    return OpenAI(
+        base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
+    )
 
 
 def create_test_user(

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -5,7 +5,7 @@ import uuid
 import pytest as pytest
 import requests
 
-from .utils import create_test_user
+from .conftest import create_test_user
 
 logger = logging.getLogger(__name__)
 test_id = str(uuid.uuid4())

--- a/tests/e2e/test_llama.py
+++ b/tests/e2e/test_llama.py
@@ -1,18 +1,14 @@
 from pathlib import Path
 
+
 import pytest
-from openai import InternalServerError, OpenAI
+from openai import InternalServerError
 
-from .utils import create_test_user
-
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
 
 model_name = "llama-cpp-python"
 
 
-def test_chat_completions():
+def test_chat_completions(client):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is your name?"},
@@ -28,7 +24,7 @@ def test_chat_completions():
     assert len(chat_completion.choices[0].message.content) < 500
 
 
-def test_embeddings():
+def test_embeddings(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.embeddings.create(
             model=model_name,
@@ -37,7 +33,7 @@ def test_embeddings():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_transcriptions():
+def test_transcriptions(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.audio.transcriptions.create(
             model=model_name, file=Path("tests/data/0min12sec.wav")

--- a/tests/e2e/test_supabase.py
+++ b/tests/e2e/test_supabase.py
@@ -1,6 +1,6 @@
 import requests
 
-from .utils import ANON_KEY
+from .conftest import ANON_KEY
 
 health_urls = {
     "auth_health_url": "http://supabase-kong.uds.dev/auth/v1/health",

--- a/tests/e2e/test_text_embeddings.py
+++ b/tests/e2e/test_text_embeddings.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from openai import InternalServerError, OpenAI
+from openai import InternalServerError
 
 model_name = "text-embeddings"
 
@@ -38,7 +38,7 @@ def test_embeddings(client):
     assert len(embedding_response.data[0].embedding) < 1000
 
 
-def test_transcriptions():
+def test_transcriptions(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.audio.transcriptions.create(
             model=model_name, file=Path("tests/data/0min12sec.wav")

--- a/tests/e2e/test_text_embeddings.py
+++ b/tests/e2e/test_text_embeddings.py
@@ -3,16 +3,10 @@ from pathlib import Path
 import pytest
 from openai import InternalServerError, OpenAI
 
-from .utils import create_test_user
-
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
-
 model_name = "text-embeddings"
 
 
-def test_completions():
+def test_completions(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.completions.create(
             model=model_name,
@@ -21,7 +15,7 @@ def test_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_chat_completions():
+def test_chat_completions(client):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "This should result in a failure"},
@@ -32,7 +26,7 @@ def test_chat_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_embeddings():
+def test_embeddings(client):
     embedding_response = client.embeddings.create(
         model=model_name,
         input="This should result in a failure",

--- a/tests/e2e/test_whisper.py
+++ b/tests/e2e/test_whisper.py
@@ -3,12 +3,6 @@ from pathlib import Path
 import pytest
 from openai import InternalServerError, OpenAI
 
-from .utils import create_test_user
-
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
-
 
 def test_completions():
     with pytest.raises(InternalServerError) as excinfo:
@@ -19,7 +13,7 @@ def test_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_chat_completions():
+def test_chat_completions(client):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "This should result in a failure"},
@@ -30,7 +24,7 @@ def test_chat_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_embeddings():
+def test_embeddings(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.embeddings.create(
             model="whisper",
@@ -39,7 +33,7 @@ def test_embeddings():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_transcriptions():
+def test_transcriptions(client):
     transcription = client.audio.transcriptions.create(
         model="whisper", file=Path("tests/data/0min12sec.wav")
     )

--- a/tests/e2e/test_whisper.py
+++ b/tests/e2e/test_whisper.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 
 import pytest
-from openai import InternalServerError, OpenAI
+from openai import InternalServerError
 
-
-def test_completions():
+def test_completions(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.completions.create(
             model="whisper",

--- a/tests/e2e/test_whisper.py
+++ b/tests/e2e/test_whisper.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 from openai import InternalServerError
 
+
 def test_completions(client):
     with pytest.raises(InternalServerError) as excinfo:
         client.completions.create(


### PR DESCRIPTION
This turns our OpenAI client into a fixture inside the `conftest.py` file, which is available to all tests in the directory, and will be loaded once when the test process starts.