### PR TITLE
chore: Fill in package READMEs and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,21 @@ The LeapfrogAI repository follows a monorepo structure based around an [API](#ap
 ```shell
 leapfrogai/
 ├── src/
-│   ├── leapfrogai_api/     # source code for the API
-│   ├── leapfrogai_sdk/     # source code for the SDK
-│   └── leapfrogai_ui/      # source code for the UI
+│   ├── leapfrogai_api/   # source code for the API
+│   ├── leapfrogai_sdk/   # source code for the SDK
+│   └── leapfrogai_ui/    # source code for the UI
 ├── packages/
-│   ├── api/                # deployment infrastructure for the API
-│   ├── llama-cpp-python/   # source code & deployment infrastructure for the llama-cpp-python backend
-│   ├── repeater/           # source code & deployment infrastructure for the repeater model backend  
-│   ├── supabase/           # deployment infrastructure for the supabase database
-│   ├── text-embeddings/    # source code & deployment infrastructure for the text-embeddings backend
-│   ├── ui/                 # deployment infrastructure for the UI
-│   ├── vllm/               # source code & deployment infrastructure for the vllm backend
-│   └── whisper/            # source code & deployment infrastructure for the whisper backend
+│   ├── api/              # deployment infrastructure for the API
+│   ├── llama-cpp-python/ # source code & deployment infrastructure for the llama-cpp-python backend
+│   ├── repeater/         # source code & deployment infrastructure for the repeater model backend  
+│   ├── supabase/         # deployment infrastructure for the Supabase backend and postgres database
+│   ├── text-embeddings/  # source code & deployment infrastructure for the text-embeddings backend
+│   ├── ui/               # deployment infrastructure for the UI
+│   ├── vllm/             # source code & deployment infrastructure for the vllm backend
+│   └── whisper/          # source code & deployment infrastructure for the whisper backend
 ├── uds-bundles/
-│   ├── dev/                # uds bundles for local uds dev deployments
-│   └── latest/             # uds bundles for the most current uds deployments
+│   ├── dev/              # uds bundles for local uds dev deployments
+│   └── latest/           # uds bundles for the most current uds deployments
 ├── Makefile
 ├── pyproject.toml
 ├── README.md
@@ -121,7 +121,7 @@ If you want to make some changes to LeapfrogAI before deploying via UDS (for exa
 
 ### Local Dev
 
-Each of the LFAI components can also be run individually outside a deployment environment via local development. This is useful when testing changes to a specific component, but will not assist in a full deployment of LeapfrogAI. Please refer to the above sections for deployment instructions.
+Each of the LFAI components can also be run individually outside of a Kubernetes environment via local development. This is useful when testing changes to a specific component, but will not assist in a full deployment of LeapfrogAI. Please refer to the above sections for deployment instructions.
 
 Please refer to the linked READMEs for each individual packages local development instructions:
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 - [Usage](#usage)
   - [UDS (Latest)](#uds-latest)
   - [UDS (Dev)](#uds-dev)
-    - [Accessing the UI](#accessing-the-ui)
-    - [Cleanup](#cleanup)
   - [Local Dev](#local-dev)
 - [Community](#community)
 
@@ -120,47 +118,6 @@ LeapfrogAI can be deployed and run locally via UDS and Kubernetes, built out usi
 
 If you want to make some changes to LeapfrogAI before deploying via UDS (for example in a dev environment), follow the [UDS Dev Instructions](/uds-bundles/dev/README.md).
 
-#### Accessing the UI
-
-LeapfrogAI is integrated with the UDS Core KeyCloak service, which provides authentication via SSO. Below are general instructions for accessing the LeapfrogAI UI after a successful UDS deployment of UDS Core and LeapfrogAI.
-
-1. Connect to the KeyCloak admin panel
-    - Run the following to get a port-forwarded tunnel:  `uds zarf connect keycloak`
-    - Go to the resulting localhost URL and create an admin account
-
-2. Go to ai.uds.dev and press "Login using SSO"
-
-3. Register a new user by pressing "Register Here"
-
-4. Fill-in all of the information
-    - The bot detection requires you to scroll and click around in a natural way, so if the Register button is not activated despite correct information, try moving around the page until the bot detection says 100% verified
-
-5. Using an authenticator, follow the MFA steps
-
-6. Go to sso.uds.dev
-    - Login using the admin account you created earlier
-
-7. Approve the newly registered user
-    - Click on the hamburger menu in the top left to open/close the sidebar
-    - Go to the dropdown that likely says "Keycloak" and switch to the "uds" context
-    - Click "Users" in the sidebar
-    - Click on the newly registered user's username
-    - Go to the "Email Verified" switch and toggle it to be "Yes"
-    - Scroll to the bottom and press "Save"
-
-8. Go back to ai.uds.dev and login as the registered user to access the UI
-
-#### Cleanup
-
-To clean-up or perform a fresh install, run the following commands in the context in which you had previously installed UDS Core and LeapfrogAI:
-
-```bash
-k3d cluster delete uds  # kills a running uds cluster
-uds zarf tools clear-cache # clears the Zarf tool cache
-rm -rf ~/.uds-cache # clears the UDS cache
-docker system prune -a -f # removes all hanging containers and images
-docker volume prune -f # removes all hanging container volumes
-```
 
 ### Local Dev
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@
 - [Usage](#usage)
   - [UDS (Latest)](#uds-latest)
   - [UDS (Dev)](#uds-dev)
-    - [CPU](#cpu)
-    - [GPU](#gpu)
-  - [Accessing the UI](#accessing-the-ui)
-  - [Cleanup](#cleanup)
+    - [Accessing the UI](#accessing-the-ui)
+    - [Cleanup](#cleanup)
   - [Local Dev](#local-dev)
 - [Community](#community)
 
@@ -120,59 +118,9 @@ LeapfrogAI can be deployed and run locally via UDS and Kubernetes, built out usi
 
 ### UDS (Dev)
 
-If you want to make some changes to LeapfrogAI before deploying via UDS (for example in a dev environment), you can follow these instructions:
+If you want to make some changes to LeapfrogAI before deploying via UDS (for example in a dev environment), follow the [UDS Dev Instructions](/uds-bundles/dev/README.md).
 
-Make sure your system has the [required dependencies](https://docs.leapfrog.ai/docs/local-deploy-guide/quick_start/#prerequisites).
-
-For ease, it's best to create a virtual environment:
-
-```shell
-python -m venv .venv
-source .venv/bin/activate
-```
-
-Each component is built into its own Zarf package. You can build all of the packages you need at once with the following `Make` targets:
-
-```shell
-make build-cpu    # api, llama-cpp-python, text-embeddings, whisper, supabase
-make build-gpu    # api, vllm, text-embeddings, whisper, supabase
-make build-all    # all of the backends
-```
-
-**OR**
-
-You can build components individually using the following `Make` targets:
-
-```shell
-make build-api
-make build-supabase
-make build-vllm                 # if you have GPUs
-make build-llama-cpp-python     # if you have CPU only
-make build-text-embeddings
-make build-whisper
-```
-
-Once the packages are created, you can deploy either a CPU or GPU-enabled deployment via one of the UDS bundles:
-
-#### CPU
-
-```shell
-cd uds-bundles/dev/cpu
-uds create .
-uds deploy k3d-core-slim-dev:0.22.2
-uds deploy uds-bundle-leapfrogai*.tar.zst
-```
-
-#### GPU
-
-```shell
-cd uds-bundles/dev/gpu
-uds create .
-uds deploy k3d-core-slim-dev:0.22.2 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"     # be sure to check if a newer version exists
-uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
-```
-
-### Accessing the UI
+#### Accessing the UI
 
 LeapfrogAI is integrated with the UDS Core KeyCloak service, which provides authentication via SSO. Below are general instructions for accessing the LeapfrogAI UI after a successful UDS deployment of UDS Core and LeapfrogAI.
 
@@ -202,7 +150,7 @@ LeapfrogAI is integrated with the UDS Core KeyCloak service, which provides auth
 
 8. Go back to ai.uds.dev and login as the registered user to access the UI
 
-### Cleanup
+#### Cleanup
 
 To clean-up or perform a fresh install, run the following commands in the context in which you had previously installed UDS Core and LeapfrogAI:
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
   - [Repeater](#repeater)
   - [Image Hardening](#image-hardening)
 - [Usage](#usage)
-  - [UDS (Latest)](#uds-latest)
-  - [UDS (Dev)](#uds-dev)
+  - [UDS](#uds)
+    - [UDS Latest](#uds-latest)
+    - [UDS Dev](#uds-dev)
   - [Local Dev](#local-dev)
 - [Community](#community)
 
@@ -110,11 +111,21 @@ LeapfrogAI leverages Chainguard's [apko](https://github.com/chainguard-dev/apko)
 
 ## Usage
 
-### UDS (Latest)
+### UDS
 
-LeapfrogAI can be deployed and run locally via UDS and Kubernetes, built out using [Zarf](https://zarf.dev) packages. This pulls the most recent package images and is the most stable way of running a local LeapfrogAI deployment. These instructions can be found on the [LeapfrogAI Docs](https://docs.leapfrog.ai/docs/) site.
+LeapfrogAI can be deployed and run locally via UDS and Kubernetes, built out using [Zarf](https://zarf.dev) packages. See the [Quick Start](https://docs.leapfrog.ai/docs/local-deploy-guide/quick_start/#prerequisites) for a list of prerequisite packages that must be installed first.
 
-### UDS (Dev)
+Prior to deploying any LeapfrogAI packages, a UDS Kubernetes cluster must be deployed using the most recent k3d bundle:
+
+```sh
+uds deploy k3d-core-slim-dev:0.22.2
+```
+
+#### UDS Latest
+
+This type of deployment pulls the most recent package images and is the most stable way of running a local LeapfrogAI deployment. These instructions can be found on the [LeapfrogAI Docs](https://docs.leapfrog.ai/docs/) site.
+
+#### UDS Dev
 
 If you want to make some changes to LeapfrogAI before deploying via UDS (for example in a dev environment), follow the [UDS Dev Instructions](/uds-bundles/dev/README.md).
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 - [Components](#components)
   - [API](#api)
   - [Backends](#backends)
-  - [Image Hardening](#image-hardening)
   - [SDK](#sdk)
   - [User Interface](#user-interface)
   - [Repeater](#repeater)
+  - [Image Hardening](#image-hardening)
 - [Usage](#usage)
   - [UDS (Latest)](#uds-latest)
   - [UDS (Dev)](#uds-dev)
@@ -90,14 +90,6 @@ LeapfrogAI provides several backends for a variety of use cases.
 > | [text-embeddings](packages/text-embeddings/) | ✅ | 🚧 | ✅ | ✅ | ✅ | ✅ |
 > | [vllm](packages/vllm/) | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 
-### Image Hardening
-
-> GitHub Repo:
->
-> - [leapfrogai-images](https://github.com/defenseunicorns/leapfrogai-images)
-
-LeapfrogAI leverages Chainguard's [apko](https://github.com/chainguard-dev/apko) to harden base python images - pinning Python versions to the latest supported version by the other components of the LeapfrogAI stack.
-
 ### SDK
 
 The LeapfrogAI [SDK](src/leapfrogai_sdk/) provides a standard set of protobuff and python utilities for implementing backends and gRPC.
@@ -109,6 +101,14 @@ LeapfrogAI provides a [User Interface](src/leapfrogai_ui/) with support for comm
 ### Repeater
 
 The [repeater](packages/repeater/) "model" is a basic "backend" that parrots all inputs it receives back to the user. It is built out the same way all the actual backends are and it primarily used for testing the API.
+
+### Image Hardening
+
+> GitHub Repo:
+>
+> - [leapfrogai-images](https://github.com/defenseunicorns/leapfrogai-images)
+
+LeapfrogAI leverages Chainguard's [apko](https://github.com/chainguard-dev/apko) to harden base python images - pinning Python versions to the latest supported version by the other components of the LeapfrogAI stack.
 
 ## Usage
 

--- a/packages/llama-cpp-python/README.md
+++ b/packages/llama-cpp-python/README.md
@@ -56,13 +56,10 @@ source .venv/bin/activate
 # Install dependencies
 python -m pip install src/leapfrogai_sdk
 cd packages/llama-cpp-python
-python -m pip install .[dev]
+python -m pip install ".[dev]"
 ```
 
 ```bash
-# Copy the config example and make changes as needed
-cp config.example.yaml config.yaml
-
 # Clone Model
 # Supply a REPO_ID, FILENAME and REVISION if a different model is desired
 python scripts/model_download.py

--- a/packages/llama-cpp-python/README.md
+++ b/packages/llama-cpp-python/README.md
@@ -34,8 +34,9 @@ REVISION  # eg: "3f65d882253d1f15a113dabf473a7c02a004d2b5"
 
 To build and deploy just the llama-cpp-python Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-llama-cpp-python LOCAL_VERSION=dev
 uds zarf package deploy packages/llama-cpp-python/zarf-package-llama-cpp-python-*-dev.tar.zst --confirm
 ```

--- a/packages/llama-cpp-python/README.md
+++ b/packages/llama-cpp-python/README.md
@@ -24,27 +24,26 @@ The default model that comes with this backend in this repository's officially r
 
 ### Run Locally
 
+
+To run the llama-cpp-python backend locally (starting from the root directory of the repository):
+
 From this directory:
 ```bash
 # Setup Virtual Environment
 python -m venv .venv
 source .venv/bin/activate
-
-python -m pip install ../../src/leapfrogai_sdk
-python -m pip install .
 ```
 
 ```bash
-# To support Huggingface Hub model downloads
-python -m pip install ".[dev]"
+# Install dependencies
+python -m pip install src/leapfrogai_sdk
+cd packages/llama-cpp-python
+python -m pip install .[dev]
 ```
 
 ```bash
-# Copy the environment variable file, change this if different params are needed
-cp .env.example .env
-
-# Make sure environment variables are set
-source .env
+# Copy the config example and make changes as needed
+cp config.example.yaml config.yaml
 
 # Clone Model
 # Supply a REPO_ID, FILENAME and REVISION if a different model is desired
@@ -53,5 +52,5 @@ python scripts/model_download.py
 mv .model/*.gguf .model/model.gguf
 
 # Start Model Backend
-python -m leapfrogai_sdk.cli --app-dir=. main:Model
+lfai-cli --app-dir=. main:Model
 ```

--- a/packages/llama-cpp-python/README.md
+++ b/packages/llama-cpp-python/README.md
@@ -30,7 +30,17 @@ FILENAME  # eg: "synthia-7b-v2.0.Q4_K_M.gguf"
 REVISION  # eg: "3f65d882253d1f15a113dabf473a7c02a004d2b5"
 ```
 
-### Run Locally
+## Zarf Package Deployment
+
+To build and deploy just the llama-cpp-python Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-llama-cpp-python LOCAL_VERSION=dev
+uds zarf package deploy packages/llama-cpp-python/zarf-package-llama-cpp-python-*-dev.tar.zst --confirm
+```
+
+## Run Locally
 
 
 To run the llama-cpp-python backend locally (starting from the root directory of the repository):

--- a/packages/llama-cpp-python/README.md
+++ b/packages/llama-cpp-python/README.md
@@ -22,6 +22,14 @@ The following are additional assumptions for GPU inferencing:
 
 The default model that comes with this backend in this repository's officially released images is a [4-bit quantization of the Synthia-7b model](https://huggingface.co/TheBloke/SynthIA-7B-v2.0-GPTQ).
 
+Models are pulled from [HuggingFace Hub](https://huggingface.co/models) via the [model_download.py](/packages/llama-cpp-python/scripts/model_download.py) script. To change what model comes with the llama-cpp-python backend, set the following environment variables:
+
+```bash
+REPO_ID   # eg: "TheBloke/SynthIA-7B-v2.0-GGUF"
+FILENAME  # eg: "synthia-7b-v2.0.Q4_K_M.gguf"
+REVISION  # eg: "3f65d882253d1f15a113dabf473a7c02a004d2b5"
+```
+
 ### Run Locally
 
 

--- a/packages/repeater/README.md
+++ b/packages/repeater/README.md
@@ -11,8 +11,9 @@ The repeater model is used to verify that the API is able to both load configs f
 
 To build and deploy just the repeater Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-repeater LOCAL_VERSION=dev
 uds zarf package deploy packages/repeater/zarf-package-repeater-*-dev.tar.zst --confirm
 ```

--- a/packages/repeater/README.md
+++ b/packages/repeater/README.md
@@ -7,30 +7,40 @@ A LeapfrogAI API-compatible repeater model that simply parrots the input it is p
 
 The repeater model is used to verify that the API is able to both load configs for and send inputs to a very simple model. The repeater model fulfills this role by returning the input it recieves as output.
 
+## Zarf Package Deployment
+
+To build and deploy just the repeater Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-repeater LOCAL_VERSION=dev
+uds zarf package deploy packages/repeater/zarf-package-repeater-*-dev.tar.zst --confirm
+```
+
 ## Local Usage
 
 Here is how to run the repeater model locally to test the API:
 
 It's easiest to set up a virtual environment to keep things clean:
-```
+```bash
 python -m venv .venv
 source .venv/bin/activate
 ```
 
 First install the lfai-repeater project and dependencies. From the root of the project repository:
-```
+```bash
 pip install src/leapfrogai_sdk
 cd packages/repeater
 pip install .
 ```
 
 Next, launch the repeater model:
-```
+```bash
 python repeater.py
 ```
 
 Now the basic API tests can be run in full. In a new terminal, starting from the root of the project repository:
-```
+```bash
 export LFAI_RUN_REPEATER_TESTS=true    # this is needed to run the tests that require the repeater model, otherwise they get skipped
 pytest tests/pytest/test_api_auth.py
 ```

--- a/packages/text-embeddings/README.md
+++ b/packages/text-embeddings/README.md
@@ -11,8 +11,9 @@ A LeapfrogAI API-compatible [instructor-xl](https://huggingface.co/hkunlp/instru
 
 To build and deploy just the text-embeddings Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-text-embeddings LOCAL_VERSION=dev
 uds zarf package deploy packages/text-embeddings/zarf-package-text-embeddings-*-dev.tar.zst --confirm
 ```

--- a/packages/text-embeddings/README.md
+++ b/packages/text-embeddings/README.md
@@ -29,7 +29,7 @@ source .venv/bin/activate
 # install dependencies
 python -m pip install src/leapfrogai_sdk
 cd packages/text-embeddings
-python -m pip install .[dev]
+python -m pip install ".[dev]"
 
 # download the model
 python scripts/model_download.py

--- a/packages/text-embeddings/README.md
+++ b/packages/text-embeddings/README.md
@@ -7,7 +7,17 @@ A LeapfrogAI API-compatible [instructor-xl](https://huggingface.co/hkunlp/instru
 
 # Usage
 
-### Local Development
+## Zarf Package Deployment
+
+To build and deploy just the text-embeddings Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-text-embeddings LOCAL_VERSION=dev
+uds zarf package deploy packages/text-embeddings/zarf-package-text-embeddings-*-dev.tar.zst --confirm
+```
+
+## Local Development
 
 To run the text-embeddings backend locally (starting from the root directory of the repository):
 

--- a/packages/text-embeddings/README.md
+++ b/packages/text-embeddings/README.md
@@ -7,6 +7,23 @@ A LeapfrogAI API-compatible [instructor-xl](https://huggingface.co/hkunlp/instru
 
 # Usage
 
-:construction_worker: This documentation is still under construction. :construction_worker:
+### Local Development
 
+To run the text-embeddings backend locally (starting from the root directory of the repository):
 
+```shell
+# Setup Virtual Environment if you haven't done so already
+python -m venv .venv
+source .venv/bin/activate
+
+# install dependencies
+python -m pip install src/leapfrogai_sdk
+cd packages/text-embeddings
+python -m pip install .[dev]
+
+# download the model
+python scripts/model_download.py
+
+# start the model backend
+python -u main.py
+```

--- a/packages/vllm/README.md
+++ b/packages/vllm/README.md
@@ -33,17 +33,17 @@ You can optionally specify different models or quantization types using the foll
 
 ### Run Locally
 
-From this directory:
+To run the vllm backend locally (starting from the root directory of the repository):
 ```bash
-# Setup Virtual Environment
+# Setup Virtual Environment if you haven't done so already
 python -m venv .venv
 source .venv/bin/activate
-
-python -m pip install ../../src/leapfrogai_sdk
-python -m pip install .
 ```
 
 ```bash
+# Install dependencies
+python -m pip install src/leapfrogai_sdk
+cd packages/vllm
 # To support Huggingface Hub model downloads
 python -m pip install ".[dev]"
 ```
@@ -62,5 +62,5 @@ python src/model_download.py
 mv .model/*.gguf .model/model.gguf
 
 # Start Model Backend
-python -m leapfrogai_sdk.cli --app-dir=src/ main:Model
+lfai-cli --app-dir=src/ main:Model
 ```

--- a/packages/vllm/README.md
+++ b/packages/vllm/README.md
@@ -35,8 +35,9 @@ You can optionally specify different models or quantization types using the foll
 
 To build and deploy just the VLLM Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-vllm LOCAL_VERSION=dev
 uds zarf package deploy packages/vllm/zarf-package-vllm-*-dev.tar.zst --confirm
 ```

--- a/packages/vllm/README.md
+++ b/packages/vllm/README.md
@@ -31,7 +31,17 @@ You can optionally specify different models or quantization types using the foll
 - `--build-arg QUANTIZATION="gptq"`: Quantization type (e.g., gptq, awq, or empty for un-quantized)
 - `--build-arg TENSOR_PARALLEL_SIZE="1"`: The number of gpus to spread the tensor processing across
 
-### Run Locally
+## Zarf Package Deployment
+
+To build and deploy just the VLLM Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-vllm LOCAL_VERSION=dev
+uds zarf package deploy packages/vllm/zarf-package-vllm-*-dev.tar.zst --confirm
+```
+
+## Run Locally
 
 To run the vllm backend locally (starting from the root directory of the repository):
 ```bash

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -5,7 +5,19 @@ A LeapfrogAI API-compatible [whisper](https://huggingface.co/openai/whisper-base
 
 # Usage
 
-To run the vllm backend locally (starting from the root directory of the repository):
+## Zarf Package Deployment
+
+To build and deploy just the whisper Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-whisper LOCAL_VERSION=dev
+uds zarf package deploy packages/whisper/zarf-package-whisper-*-dev.tar.zst --confirm
+```
+
+## Local Development
+
+To run the vllm backend locally without K8s (starting from the root directory of the repository):
 
 ```shell
 python -m pip install src/leapfrogai_sdk

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -5,5 +5,12 @@ A LeapfrogAI API-compatible [whisper](https://huggingface.co/openai/whisper-base
 
 # Usage
 
-:construction_worker: This documentation is still under construction. :construction_worker:
+To run the vllm backend locally (starting from the root directory of the repository):
 
+```shell
+python -m pip install src/leapfrogai_sdk
+cd packages/whisper
+python -m pip install ".[dev]"
+ct2-transformers-converter --model openai/whisper-base --output_dir .model --copy_files tokenizer.json --quantization float32
+python -u main.py
+```

--- a/packages/whisper/README.md
+++ b/packages/whisper/README.md
@@ -9,8 +9,9 @@ A LeapfrogAI API-compatible [whisper](https://huggingface.co/openai/whisper-base
 
 To build and deploy just the whisper Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-whisper LOCAL_VERSION=dev
 uds zarf package deploy packages/whisper/zarf-package-whisper-*-dev.tar.zst --confirm
 ```

--- a/src/leapfrogai_api/README.md
+++ b/src/leapfrogai_api/README.md
@@ -6,8 +6,9 @@ A mostly OpenAI compliant API surface.
 
 To build and deploy just the API Zarf package (from the root of the repository):
 
+> Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
 ```shell
-uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
 make build-api LOCAL_VERSION=dev
 uds zarf package deploy packages/api/zarf-package-leapfrogai-api-*-dev.tar.zst --confirm
 ```

--- a/src/leapfrogai_api/README.md
+++ b/src/leapfrogai_api/README.md
@@ -2,6 +2,16 @@
 
 A mostly OpenAI compliant API surface.
 
+## Zarf Package Deployment
+
+To build and deploy just the API Zarf package (from the root of the repository):
+
+```shell
+uds deploy k3d-core-slim-dev:0.22.2      # if no cluster exists already
+make build-api LOCAL_VERSION=dev
+uds zarf package deploy packages/api/zarf-package-leapfrogai-api-*-dev.tar.zst --confirm
+```
+
 ## Local Development Setup
 
 1. Install dependencies

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,12 +16,10 @@ The tests in this directory are also able to be run locally! We are currently op
 
 There are several ways you can setup and run these tests. Here is one such way:
 
-```bash
-# Setup the UDS cluster
-# NOTE: This stands up a k3d cluster and installs istio & pepr
-# NOTE: Be sure to use the latest released version at the time you're reading this!
-uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-slim-dev:0.22.2 --confirm
+> Deploy the [UDS cluster](/README.md#uds) \
+> NOTE: This stands up a k3d cluster and installs istio & pepr
 
+```bash
 # Build and Deploy the LFAI API
 make build-api
 uds zarf package deploy zarf-package-leapfrogai-api-*.tar.zst

--- a/uds-bundles/dev/README.md
+++ b/uds-bundles/dev/README.md
@@ -51,3 +51,7 @@ uds create .
 uds deploy k3d-core-slim-dev:0.22.2 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"     # be sure to check if a newer version exists
 uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
 ```
+
+## Checking and Managing the Deployment
+
+For tips on how to monitor the deployment, accessing the UI, and clean up, please reference the [Quick Start](https://docs.leapfrog.ai/docs/local-deploy-guide/quick_start/#checking-deployment) guide in the LeapfrogAI docs.

--- a/uds-bundles/dev/README.md
+++ b/uds-bundles/dev/README.md
@@ -1,0 +1,53 @@
+# LeapfrogAI UDS Dev Deployment Instructions
+
+Follow these instructions to create a local development deployment of LeapfrogAI using [UDS](https://github.com/defenseunicorns/uds-core).
+
+Make sure your system has the [required dependencies](https://docs.leapfrog.ai/docs/local-deploy-guide/quick_start/#prerequisites).
+
+For ease, it's best to create a virtual environment:
+
+```shell
+python -m venv .venv
+source .venv/bin/activate
+```
+
+Each component is built into its own Zarf package. You can build all of the packages you need at once with the following `Make` targets:
+
+```shell
+make build-cpu    # api, llama-cpp-python, text-embeddings, whisper, supabase
+make build-gpu    # api, vllm, text-embeddings, whisper, supabase
+make build-all    # all of the backends
+```
+
+**OR**
+
+You can build components individually using the following `Make` targets:
+
+```shell
+make build-api
+make build-supabase
+make build-vllm                 # if you have GPUs
+make build-llama-cpp-python     # if you have CPU only
+make build-text-embeddings
+make build-whisper
+```
+
+Once the packages are created, you can deploy either a CPU or GPU-enabled deployment via one of the UDS bundles:
+
+## CPU
+
+```shell
+cd uds-bundles/dev/cpu
+uds create .
+uds deploy k3d-core-slim-dev:0.22.2
+uds deploy uds-bundle-leapfrogai*.tar.zst
+```
+
+## GPU
+
+```shell
+cd uds-bundles/dev/gpu
+uds create .
+uds deploy k3d-core-slim-dev:0.22.2 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"     # be sure to check if a newer version exists
+uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
+```

--- a/uds-bundles/dev/README.md
+++ b/uds-bundles/dev/README.md
@@ -36,19 +36,35 @@ Once the packages are created, you can deploy either a CPU or GPU-enabled deploy
 
 ## CPU
 
+Create the uds CPU bundle:
 ```shell
 cd uds-bundles/dev/cpu
 uds create .
-uds deploy k3d-core-slim-dev:0.22.2
+```
+
+Deploy a [UDS cluster](/README.md#uds) if one isn't deployed already
+
+Deploy the LeapfrogAI bundle:
+```shell
 uds deploy uds-bundle-leapfrogai*.tar.zst
 ```
 
 ## GPU
 
+Create the uds GPU bundle:
 ```shell
 cd uds-bundles/dev/gpu
 uds create .
-uds deploy k3d-core-slim-dev:0.22.2 --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"     # be sure to check if a newer version exists
+```
+
+Deploy a [UDS cluster](/README.md#uds) with the following flags, as so:
+
+```shell
+uds deploy {k3d-cluster-name} --set K3D_EXTRA_ARGS="--gpus=all --image=ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda"
+```
+
+Deploy the LeapfrogAI bundle:
+```shell
 uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
 ```
 

--- a/website/content/en/docs/local deploy guide/quick_start.md
+++ b/website/content/en/docs/local deploy guide/quick_start.md
@@ -12,6 +12,7 @@ The fastest and easiest way to get started with a deployment of LeapfrogAI is by
 
 - [Docker](https://docs.docker.com/engine/install/)
 - [K3D](https://k3d.io/)
+- [Zarf](https://docs.zarf.dev/getting-started/install/)
 - [UDS CLI](https://github.com/defenseunicorns/uds-cli)
 
 GPU considerations (NVIDIA GPUs only):


### PR DESCRIPTION
- Moves local dev instructions out from the root `README.md` and into each packages' respective `README.md`
- Adds zarf deploy instructions to package READMEs
- Removes redundant instructions in some places
- Misc updates to package READMEs 