### PR TITLE
chore(api): raise exception on CRUD base fails

### DIFF
--- a/src/leapfrogai_api/data/crud_base.py
+++ b/src/leapfrogai_api/data/crud_base.py
@@ -78,6 +78,7 @@ class CRUDBase(Generic[ModelType]):
         except Exception as exc:
             raise Exception from exc
 
+
     async def update(self, id_: str, object_: ModelType) -> ModelType | None:
         """Update a row by its ID."""
 

--- a/src/leapfrogai_api/data/crud_base.py
+++ b/src/leapfrogai_api/data/crud_base.py
@@ -38,8 +38,8 @@ class CRUDBase(Generic[ModelType]):
             if "user_id" in response[0]:
                 del response[0]["user_id"]
             return self.model(**response[0])
-        except Exception:
-            return None
+        except Exception as e:
+            raise e
 
     async def get(self, filters: dict | None = None) -> ModelType | None:
         """Get row by filters."""
@@ -77,8 +77,6 @@ class CRUDBase(Generic[ModelType]):
                 if "user_id" in item:
                     del item["user_id"]
             return [self.model(**item) for item in response]
-        except IndexError:
-            return None
         except Exception as e:
             raise e
 
@@ -121,9 +119,10 @@ class CRUDBase(Generic[ModelType]):
         """Get the user_id from the API key."""
 
         if self.db.options.headers.get("x-custom-api-key"):
-            data, _count = await self.db.table("api_keys").select("user_id").execute()
-            _, tmp = data
-            user_id: str = tmp[0]["user_id"]
+            result = await self.db.table("api_keys").select("user_id").execute()
+            # _, tmp = data
+            # user_id: str = tmp[0]["user_id"]
+            user_id: str = result.data[0]["user_id"]
         else:
             user_id = (await self.db.auth.get_user()).user.id
 

--- a/src/leapfrogai_api/data/crud_base.py
+++ b/src/leapfrogai_api/data/crud_base.py
@@ -56,8 +56,10 @@ class CRUDBase(Generic[ModelType]):
             if "user_id" in response[0]:
                 del response[0]["user_id"]
             return self.model(**response[0])
-        except Exception:
+        except IndexError:
             return None
+        except Exception as e:
+            raise e
 
     async def list(self, filters: dict | None = None) -> list[ModelType]:
         """List all rows."""
@@ -75,9 +77,10 @@ class CRUDBase(Generic[ModelType]):
                 if "user_id" in item:
                     del item["user_id"]
             return [self.model(**item) for item in response]
-        except Exception as exc:
-            raise Exception from exc
-
+        except IndexError:
+            return None
+        except Exception as e:
+            raise e
 
     async def update(self, id_: str, object_: ModelType) -> ModelType | None:
         """Update a row by its ID."""
@@ -94,8 +97,10 @@ class CRUDBase(Generic[ModelType]):
             if "user_id" in response[0]:
                 del response[0]["user_id"]
             return self.model(**response[0])
-        except Exception:
+        except IndexError:
             return None
+        except Exception as e:
+            raise e
 
     async def delete(self, filters: dict | None = None) -> bool:
         """Delete a row by filters."""

--- a/src/leapfrogai_api/data/crud_base.py
+++ b/src/leapfrogai_api/data/crud_base.py
@@ -120,8 +120,6 @@ class CRUDBase(Generic[ModelType]):
 
         if self.db.options.headers.get("x-custom-api-key"):
             result = await self.db.table("api_keys").select("user_id").execute()
-            # _, tmp = data
-            # user_id: str = tmp[0]["user_id"]
             user_id: str = result.data[0]["user_id"]
         else:
             user_id = (await self.db.auth.get_user()).user.id

--- a/tests/mocks/mock_session.py
+++ b/tests/mocks/mock_session.py
@@ -8,6 +8,7 @@ from .mock_tables import (
     mock_run,
     mock_message,
     mock_data_model,
+    mock_api_key,
 )
 
 _mocks_cache = {}
@@ -67,6 +68,7 @@ def mock_execute_data(table_name):
         assistant=mock_assistant,
         message=mock_message,
         dummy_table=mock_data_model,
+        api_keys=mock_api_key,
     )
     if table_name:
         return mock_map[table_name]

--- a/tests/mocks/mock_tables.py
+++ b/tests/mocks/mock_tables.py
@@ -46,3 +46,10 @@ mock_message = Message(
         TextContentBlock(text=Text(value="mock-data", annotations=[]), type="text")
     ],
 )
+
+
+class MockApiKey(BaseModel):
+    user_id: str
+
+
+mock_api_key = MockApiKey(user_id="mock-api-key")

--- a/tests/unit/leapfrogai_api/data/test_crud_base.py
+++ b/tests/unit/leapfrogai_api/data/test_crud_base.py
@@ -105,9 +105,8 @@ async def test_create_fail(mock_session, mock_response):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.insert().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.create(mock_data_model)
-
-    assert result is None
+    with pytest.raises(AttributeError):
+        await mock_crud_base.create(mock_data_model)
 
 
 @pytest.mark.asyncio
@@ -142,36 +141,32 @@ async def test_get_fail(mock_session, filters, mock_response):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.get(filters)
-
-    assert result is None
+    with pytest.raises(AttributeError):
+        await mock_crud_base.get(filters)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "filters, mock_response, expected_result",
+    "mock_response, expected_result",
     [
         (
-            {"id": 1},
             [dict(id=1, name="mock-data")],
             [MockModel(id=1, name="mock-data")],
         ),
         (
-            {"id": 1},
             [dict(id=1, name="mock-data"), dict(id=2, name="mock-data")],
             [MockModel(id=1, name="mock-data"), MockModel(id=2, name="mock-data")],
         ),
-        ({"id": 1}, [], None),
     ],
 )
-async def test_list(mock_session, filters, mock_response, expected_result):
+async def test_list(mock_session, mock_response, expected_result):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.list(filters)
+    result = await mock_crud_base.list({"id": 1})
 
     assert result == expected_result
 
@@ -188,9 +183,8 @@ async def test_list_fail(mock_session, filters, mock_response):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.get(filters)
-
-    assert result is None
+    with pytest.raises(AttributeError):
+        await mock_crud_base.get(filters)
 
 
 @pytest.mark.asyncio
@@ -220,9 +214,8 @@ async def test_update_fail(mock_session, mock_response):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.update().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.update("1", mock_data_model)
-
-    assert result is None
+    with pytest.raises(AttributeError):
+        await mock_crud_base.update("1", mock_data_model)
 
 
 @pytest.mark.asyncio
@@ -245,6 +238,5 @@ async def test_delete_fail(mock_session, mock_response):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.delete().execute.return_value = execute_response_format(mock_response)
 
-    result = await mock_crud_base.update("1", mock_data_model)
-
-    assert result is None
+    with pytest.raises(AttributeError):
+        await mock_crud_base.delete({"id": 1})

--- a/tests/unit/leapfrogai_api/data/test_crud_base.py
+++ b/tests/unit/leapfrogai_api/data/test_crud_base.py
@@ -1,6 +1,6 @@
 import pytest
-from pydantic import BaseModel
-from tests.utils.crud_utils import execute_response_format
+from pydantic import BaseModel, ValidationError
+from tests.utils.crud_utils import MockAPIResponse
 from tests.mocks.mock_tables import mock_data_model, MockModel
 
 from src.leapfrogai_api.data.crud_base import CRUDBase
@@ -83,7 +83,9 @@ async def test_create(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.insert().execute.return_value = execute_response_format(mock_response)
+    mock_table.insert.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
     result = await mock_crud_base.create(mock_data_object)
 
@@ -103,25 +105,30 @@ async def test_create_fail(mock_session, mock_response):
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.insert().execute.return_value = execute_response_format(mock_response)
+    mock_table.insert.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(Exception):
         await mock_crud_base.create(mock_data_model)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "filters, mock_response, expected_result",
-    [({"id": 1}, [dict(id=1, name="mock-data")], MockModel(id=1, name="mock-data"))],
+    "mock_response, expected_result",
+    [([dict(id=1, name="mock-data")], MockModel(id=1, name="mock-data")), ([], None)],
 )
-async def test_get(mock_session, filters, mock_response, expected_result):
+async def test_get(mock_session, mock_response, expected_result):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.select().execute.return_value = execute_response_format(mock_response)
+    mock_table.select.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    result = await mock_crud_base.get(filters)
+    mock_filters = {"id": 1}
+    result = await mock_crud_base.get(mock_filters)
 
     if expected_result:
         assert result == expected_result
@@ -131,17 +138,24 @@ async def test_get(mock_session, filters, mock_response, expected_result):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "filters, mock_response",
-    [({"id": 1}, []), ({"id": 1}, {}), ({"id": 1}, None), ({}, None), (None, None)],
+    "filters, mock_response, expected_error",
+    [
+        ({"id": 1}, {}, ValidationError),
+        (None, {}, ValidationError),
+        ({"id": 1}, None, TypeError),
+        (None, None, TypeError),
+    ],
 )
-async def test_get_fail(mock_session, filters, mock_response):
+async def test_get_fail(mock_session, filters, mock_response, expected_error):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.select().execute.return_value = execute_response_format(mock_response)
+    mock_table.select.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(expected_error):
         await mock_crud_base.get(filters)
 
 
@@ -157,6 +171,7 @@ async def test_get_fail(mock_session, filters, mock_response):
             [dict(id=1, name="mock-data"), dict(id=2, name="mock-data")],
             [MockModel(id=1, name="mock-data"), MockModel(id=2, name="mock-data")],
         ),
+        ([], None),
     ],
 )
 async def test_list(mock_session, mock_response, expected_result):
@@ -164,7 +179,9 @@ async def test_list(mock_session, mock_response, expected_result):
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.select().execute.return_value = execute_response_format(mock_response)
+    mock_table.select.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
     result = await mock_crud_base.list({"id": 1})
 
@@ -173,31 +190,38 @@ async def test_list(mock_session, mock_response, expected_result):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "filters, mock_response",
-    [({"id": 1}, {}), ({"id": 1}, None), ({}, None), (None, None)],
+    "filters, mock_response, expected_error",
+    [
+        ({"id": 1}, {}, ValidationError),
+        ({"id": 1}, None, TypeError),
+        ({}, None, TypeError),
+        (None, None, TypeError),
+    ],
 )
-async def test_list_fail(mock_session, filters, mock_response):
+async def test_list_fail(mock_session, filters, mock_response, expected_error):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.select().execute.return_value = execute_response_format(mock_response)
+    mock_table.select.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(expected_error):
         await mock_crud_base.get(filters)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "mock_response, expected_result", [(mock_data_model, mock_data_model)]
+    "mock_response, expected_result", [(mock_data_model, mock_data_model), ([], None)]
 )
 async def test_update(mock_session, mock_response, expected_result):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.update().execute.return_value = execute_response_format(
-        mock_response.model_dump()
+    mock_table.update.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response.model_dump() if mock_response else mock_response
     )
 
     result = await mock_crud_base.update("1", mock_data_model)
@@ -206,15 +230,17 @@ async def test_update(mock_session, mock_response, expected_result):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mock_response", [({}), ([]), (None)])
+@pytest.mark.parametrize("mock_response", [(None)])
 async def test_update_fail(mock_session, mock_response):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.update().execute.return_value = execute_response_format(mock_response)
+    mock_table.update.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         await mock_crud_base.update("1", mock_data_model)
 
 
@@ -230,13 +256,15 @@ async def test_delete(mock_session):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("mock_response", [({}), ([]), (None)])
+@pytest.mark.parametrize("mock_response", [([]), (None)])
 async def test_delete_fail(mock_session, mock_response):
     mock_crud_base = CRUDBase(
         db=mock_session, model=MockModel, table_name="dummy_table"
     )
     mock_table = mock_session.table(mock_crud_base.table_name)
-    mock_table.delete().execute.return_value = execute_response_format(mock_response)
+    mock_table.delete.return_value.execute.return_value = MockAPIResponse(
+        data=mock_response
+    )
 
-    with pytest.raises(AttributeError):
-        await mock_crud_base.delete({"id": 1})
+    result = await mock_crud_base.delete({"id": 1})
+    assert result is False

--- a/tests/unit/leapfrogai_api/data/test_crud_base.py
+++ b/tests/unit/leapfrogai_api/data/test_crud_base.py
@@ -25,6 +25,11 @@ class MockModelFields(BaseModel):
 mock_data_dict = dict(id=1, name="mock-data")
 
 
+@pytest.fixture
+def mock_crud_base(mock_session):
+    return CRUDBase(db=mock_session, model=MockModel, table_name="dummy_table")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "mock_data_object, mock_response, expected_result, expected_call",
@@ -77,11 +82,13 @@ mock_data_dict = dict(id=1, name="mock-data")
     ],
 )
 async def test_create(
-    mock_session, mock_data_object, mock_response, expected_result, expected_call
+    mock_data_object,
+    mock_response,
+    expected_result,
+    expected_call,
+    mock_session,
+    mock_crud_base,
 ):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.insert.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -100,10 +107,7 @@ async def test_create(
     "mock_response",
     [({}), ([]), (None)],
 )
-async def test_create_fail(mock_session, mock_response):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_create_fail(mock_response, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.insert.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -118,10 +122,7 @@ async def test_create_fail(mock_session, mock_response):
     "mock_response, expected_result",
     [([dict(id=1, name="mock-data")], MockModel(id=1, name="mock-data")), ([], None)],
 )
-async def test_get(mock_session, mock_response, expected_result):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_get(mock_response, expected_result, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -146,10 +147,9 @@ async def test_get(mock_session, mock_response, expected_result):
         (None, None, TypeError),
     ],
 )
-async def test_get_fail(mock_session, filters, mock_response, expected_error):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_get_fail(
+    filters, mock_response, expected_error, mock_session, mock_crud_base
+):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -174,10 +174,7 @@ async def test_get_fail(mock_session, filters, mock_response, expected_error):
         ([], None),
     ],
 )
-async def test_list(mock_session, mock_response, expected_result):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_list(mock_response, expected_result, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -198,10 +195,9 @@ async def test_list(mock_session, mock_response, expected_result):
         (None, None, TypeError),
     ],
 )
-async def test_list_fail(mock_session, filters, mock_response, expected_error):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_list_fail(
+    filters, mock_response, expected_error, mock_session, mock_crud_base
+):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.select.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -215,10 +211,7 @@ async def test_list_fail(mock_session, filters, mock_response, expected_error):
 @pytest.mark.parametrize(
     "mock_response, expected_result", [(mock_data_model, mock_data_model), ([], None)]
 )
-async def test_update(mock_session, mock_response, expected_result):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_update(mock_response, expected_result, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.update.return_value.execute.return_value = MockAPIResponse(
         data=mock_response.model_dump() if mock_response else mock_response
@@ -231,10 +224,7 @@ async def test_update(mock_session, mock_response, expected_result):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mock_response", [(None)])
-async def test_update_fail(mock_session, mock_response):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_update_fail(mock_response, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.update.return_value.execute.return_value = MockAPIResponse(
         data=mock_response
@@ -245,11 +235,7 @@ async def test_update_fail(mock_session, mock_response):
 
 
 @pytest.mark.asyncio
-async def test_delete(mock_session):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
-
+async def test_delete(mock_crud_base):
     result = await mock_crud_base.delete({"id": 1})
 
     assert result is True
@@ -257,10 +243,7 @@ async def test_delete(mock_session):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mock_response", [([]), (None)])
-async def test_delete_fail(mock_session, mock_response):
-    mock_crud_base = CRUDBase(
-        db=mock_session, model=MockModel, table_name="dummy_table"
-    )
+async def test_delete_fail(mock_response, mock_session, mock_crud_base):
     mock_table = mock_session.table(mock_crud_base.table_name)
     mock_table.delete.return_value.execute.return_value = MockAPIResponse(
         data=mock_response

--- a/tests/utils/crud_utils.py
+++ b/tests/utils/crud_utils.py
@@ -3,6 +3,9 @@ class MockAPIResponse:
         if isinstance(data, list):
             self.data = data
             self.count = len(data)
+        elif data is None:
+            self.data = None
+            self.count = 0
         else:
             self.data = [data]
             self.count = 1


### PR DESCRIPTION
CRUD operations will now raise exceptions instead of catching them and returning None.
- Will return None for exceptions that are due to no results from db

Delete function will only return True/False.