### PR TITLE
(chore) Remove redundancy from some class names

### DIFF
--- a/src/leapfrogai_api/routers/openai/requests/run_create_params_request.py
+++ b/src/leapfrogai_api/routers/openai/requests/run_create_params_request.py
@@ -23,7 +23,7 @@ from leapfrogai_api.backend.converters import (
 from leapfrogai_api.routers.supabase_session import Session
 
 
-class RunCreateParamsRequestBaseRequest(RunCreateParamsRequestBase):
+class RunCreateParamsRequest(RunCreateParamsRequestBase):
     additional_instructions: str | None = Field(
         default=None,
         examples=["Please provide a summary of the conversation so far."],

--- a/src/leapfrogai_api/routers/openai/requests/thread_run_create_params_request.py
+++ b/src/leapfrogai_api/routers/openai/requests/thread_run_create_params_request.py
@@ -39,7 +39,7 @@ from leapfrogai_api.routers.openai.requests.create_thread_request import (
 from leapfrogai_api.routers.supabase_session import Session
 
 
-class ThreadRunCreateParamsRequestBaseRequest(RunCreateParamsRequestBase):
+class ThreadRunCreateParamsRequest(RunCreateParamsRequestBase):
     thread: ThreadCreateAndRunsThread | None = Field(
         default=None,
         examples=[

--- a/src/leapfrogai_api/routers/openai/runs.py
+++ b/src/leapfrogai_api/routers/openai/runs.py
@@ -10,10 +10,10 @@ from leapfrogai_api.backend.types import (
     ModifyRunRequest,
 )
 from leapfrogai_api.routers.openai.requests.thread_run_create_params_request import (
-    ThreadRunCreateParamsRequestBaseRequest,
+    ThreadRunCreateParamsRequest,
 )
 from leapfrogai_api.routers.openai.requests.run_create_params_request import (
-    RunCreateParamsRequestBaseRequest,
+    RunCreateParamsRequest,
 )
 from leapfrogai_api.data.crud_run import CRUDRun
 from leapfrogai_api.data.crud_thread import CRUDThread
@@ -29,7 +29,7 @@ security = HTTPBearer()
 
 @router.post("/{thread_id}/runs", response_model=None)
 async def create_run(
-    thread_id: str, session: Session, request: RunCreateParamsRequestBaseRequest
+    thread_id: str, session: Session, request: RunCreateParamsRequest
 ) -> Run | StreamingResponse:
     """Create a run."""
 
@@ -73,7 +73,7 @@ async def create_run(
 
 @router.post("/runs", response_model=None)
 async def create_thread_and_run(
-    session: Session, request: ThreadRunCreateParamsRequestBaseRequest
+    session: Session, request: ThreadRunCreateParamsRequest
 ) -> Run | StreamingResponse:
     """Create a thread and run."""
 

--- a/tests/integration/api/test_runs.py
+++ b/tests/integration/api/test_runs.py
@@ -16,10 +16,10 @@ from leapfrogai_api.routers.openai.requests.create_thread_request import (
     CreateThreadRequest,
 )
 from leapfrogai_api.routers.openai.requests.run_create_params_request import (
-    RunCreateParamsRequestBaseRequest,
+    RunCreateParamsRequest,
 )
 from leapfrogai_api.routers.openai.requests.thread_run_create_params_request import (
-    ThreadRunCreateParamsRequestBaseRequest,
+    ThreadRunCreateParamsRequest,
 )
 
 CHAT_MODEL = "test-chat"
@@ -125,7 +125,7 @@ def create_run(app_client, create_assistant, create_thread):
     assistant_id = create_assistant.json()["id"]
     thread_id = create_thread.json()["id"]
 
-    request = RunCreateParamsRequestBaseRequest(
+    request = RunCreateParamsRequest(
         assistant_id=assistant_id,
         instructions="You are a conversational assistant.",
         additional_instructions="Respond as a Unicorn assistant named Doug.",
@@ -165,7 +165,7 @@ def test_create_thread_and_run(app_client, create_assistant):
     """Test running an assistant. Requires a running Supabase instance."""
     assistant_id = create_assistant.json()["id"]
 
-    request = ThreadRunCreateParamsRequestBaseRequest(
+    request = ThreadRunCreateParamsRequest(
         assistant_id=assistant_id,
         instructions="You are a conversational assistant.",
         additional_instructions="Respond as a Unicorn assistant named Doug.",


### PR DESCRIPTION
Adjust class names from `*CreateParamsRequestBaseRequest` to `*CreateParamsRequest`