### PR TITLE
Chore: Standardize package vars relating to domain names

### DIFF
--- a/packages/api/zarf.yaml
+++ b/packages/api/zarf.yaml
@@ -18,8 +18,6 @@ variables:
   - name: EXPOSE_OPENAPI_SCHEMA
     default: "false"
     description: "Flag to expose the OpenAPI schema for debugging."
-  - name: HOSTED_DOMAIN
-    default: "uds.dev"
   - name: DEFAULT_EMBEDDINGS_MODEL
     default: "text-embeddings"
 

--- a/packages/supabase/bitnami-values.yaml
+++ b/packages/supabase/bitnami-values.yaml
@@ -8,9 +8,9 @@ leapfrogai:
   sso:
     clientId: ###ZARF_CONST_EXTERNAL_KEYCLOAK_CLIENT_ID###
     redirectUris:
-      - "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_HOSTED_DOMAIN###/auth/v1/callback"
+      - "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_DOMAIN###/auth/v1/callback"
     webOrigins:
-      - "https://ai.###ZARF_VAR_HOSTED_DOMAIN###"
+      - "https://ai.###ZARF_VAR_DOMAIN###"
 
 global:
   jwt:
@@ -28,7 +28,7 @@ jwt:
     resourcesPreset: "none"
     podLabels:
       sidecar.istio.io/inject: "false"
-publicURL: "https://supabase-kong.###ZARF_VAR_HOSTED_DOMAIN###"
+publicURL: "https://supabase-kong.###ZARF_VAR_DOMAIN###"
 auth:
   enabled: ###ZARF_VAR_ENABLE_AUTH###
   defaultConfig: |
@@ -57,8 +57,8 @@ auth:
     GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE: "{{ include "supabase.studio.publicURL" . }}/auth/v1/verify"
     GOTRUE_EXTERNAL_KEYCLOAK_ENABLED: "###ZARF_VAR_ENABLE_EXTERNAL_KEYCLOAK###"
     GOTRUE_EXTERNAL_KEYCLOAK_CLIENT_ID: "{{ .Values.leapfrogai.sso.clientId }}"
-    GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI: "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_HOSTED_DOMAIN###/auth/v1/callback"
-    GOTRUE_EXTERNAL_KEYCLOAK_URL: "https://sso.###ZARF_VAR_HOSTED_DOMAIN###/realms/uds"
+    GOTRUE_EXTERNAL_KEYCLOAK_REDIRECT_URI: "https://{{ .Values.leapfrogai.package.host }}.###ZARF_VAR_DOMAIN###/auth/v1/callback"
+    GOTRUE_EXTERNAL_KEYCLOAK_URL: "https://sso.###ZARF_VAR_DOMAIN###/realms/uds"
   image:
     tag: 2.149.0-debian-12-r0
   resourcesPreset: "none"
@@ -104,7 +104,7 @@ storage:
 
 studio:
   enabled: ###ZARF_VAR_ENABLE_STUDIO###
-  publicURL: "https://ai.###ZARF_VAR_HOSTED_DOMAIN###"
+  publicURL: "https://ai.###ZARF_VAR_DOMAIN###"
   image:
     tag: 0.24.3-debian-12-r0
   resourcesPreset: "none"

--- a/packages/supabase/zarf.yaml
+++ b/packages/supabase/zarf.yaml
@@ -17,7 +17,7 @@ constants:
     value: '###ZARF_PKG_TMPL_IMAGE_VERSION###'
 
 variables:
-  - name: HOSTED_DOMAIN
+  - name: DOMAIN
     default: "uds.dev"
   - name: ENABLE_AUTH
     description: 'Enable Supabases built-in authentication and authorization parts'

--- a/packages/ui/chart/ui-values.yaml
+++ b/packages/ui/chart/ui-values.yaml
@@ -13,7 +13,7 @@ package:
   name: leapfrogai-ui
   subdomain: '###ZARF_VAR_SUBDOMAIN###'
   domain: '###ZARF_VAR_DOMAIN###'
-  supabase_url: '###ZARF_VAR_SUPABASE_URL###'
+  supabase_url: 'https://supabase-kong.###ZARF_VAR_DOMAIN###'
   supabase_anon_key: '###ZARF_VAR_SUPABASE_ANON_KEY###'
   message_length_limit: '###ZARF_VAR_MESSAGE_LENGTH_LIMIT###'
 

--- a/packages/ui/zarf.yaml
+++ b/packages/ui/zarf.yaml
@@ -44,11 +44,6 @@ variables:
     default: '0.1'
     prompt: true
     sensitive: false
-  - name: SUPABASE_URL
-    description: URL for supabase
-    prompt: true
-    default: https://supabase-kong.uds.dev
-    sensitive: false
   - name: SUPABASE_ANON_KEY
     default: ''
     description: Public key for Supabase

--- a/uds-bundles/dev/cpu/uds-bundle.yaml
+++ b/uds-bundles/dev/cpu/uds-bundle.yaml
@@ -11,18 +11,6 @@ packages:
   - name: supabase
     path: ../../../packages/supabase/
     ref: dev
-    overrides:
-      supabase:
-        supabase-secrets-generator:
-          variables:
-            - path: "leapfrogai.sso.redirectUris"
-              name: "KEYCLOAK_REDIRECT_URIS"
-              default:
-                - "https://supabase-kong.uds.dev/auth/v1/callback"
-            - path: "leapfrogai.sso.webOrigins"
-              name: KEYCLOAK_WEB_ORIGINS
-              default:
-                - "https://ai.uds.dev"
 
   # API
   - name: leapfrogai-api

--- a/uds-bundles/dev/cpu/uds-config.yaml
+++ b/uds-bundles/dev/cpu/uds-config.yaml
@@ -6,19 +6,11 @@ variables:
     gpu_limit: 0
 
   supabase:
-    keycloak_redirect_uris:
-      - "https://supabase-kong.uds.dev/auth/v1/callback"
-    webOrigins:
-      - "https://ai.uds.dev"
-    hosted_domain: "uds.dev"
-
-  leapfrogai-api:
-    hosted_domain: "uds.dev"
+    domain: "uds.dev"
 
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev
     model: llama-cpp-python
-    supabase_url: https://supabase-kong.uds.dev
     disable_keycloak: false # If this package is deployed as a bundle, keycloak is assumed default
     supabase_anon_key: ''

--- a/uds-bundles/dev/gpu/uds-bundle.yaml
+++ b/uds-bundles/dev/gpu/uds-bundle.yaml
@@ -11,18 +11,6 @@ packages:
   - name: supabase
     path: ../../../packages/supabase/
     ref: dev
-    overrides:
-      supabase:
-        supabase-secrets-generator:
-          variables:
-            - path: "leapfrogai.sso.redirectUris"
-              name: "KEYCLOAK_REDIRECT_URIS"
-              default:
-                - "https://supabase-kong.uds.dev/auth/v1/callback"
-            - path: "leapfrogai.sso.webOrigins"
-              name: KEYCLOAK_WEB_ORIGINS
-              default:
-                - "https://ai.uds.dev"
 
   # OpenAI-like API
   - name: leapfrogai-api

--- a/uds-bundles/dev/gpu/uds-config.yaml
+++ b/uds-bundles/dev/gpu/uds-config.yaml
@@ -11,19 +11,11 @@ variables:
     #tensor_parallel_size: 1   # TODO: reintroduce when vllm changes get pulled in
 
   supabase:
-    keycloak_redirect_uris:
-      - "https://supabase-kong.uds.dev/auth/v1/callback"
-    webOrigins:
-      - "https://ai.uds.dev"
-    hosted_domain: "uds.dev"
-
-  leapfrogai-api:
-    hosted_domain: "uds.dev"
+    domain: "uds.dev"
 
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev
     model: vllm
-    supabase_url: https://supabase-kong.uds.dev
     disable_keycloak: false # If this package is deployed as a bundle, keycloak is assumed default
     supabase_anon_key: ''

--- a/uds-bundles/latest/cpu/uds-bundle.yaml
+++ b/uds-bundles/latest/cpu/uds-bundle.yaml
@@ -15,18 +15,6 @@ packages:
     # x-release-please-start-version
     ref: 0.8.0
     # x-release-please-end
-    overrides:
-      supabase:
-        supabase-secrets-generator:
-          variables:
-            - path: "leapfrogai.sso.redirectUris"
-              name: "KEYCLOAK_REDIRECT_URIS"
-              default:
-                - "https://supabase-kong.uds.dev/auth/v1/callback"
-            - path: "leapfrogai.sso.webOrigins"
-              name: KEYCLOAK_WEB_ORIGINS
-              default:
-                - "https://ai.uds.dev"
 
   # API
   - name: leapfrogai-api

--- a/uds-bundles/latest/cpu/uds-config.yaml
+++ b/uds-bundles/latest/cpu/uds-config.yaml
@@ -6,19 +6,11 @@ variables:
     gpu_limit: 0
 
   supabase:
-    keycloak_redirect_uris:
-      - "https://supabase-kong.uds.dev/auth/v1/callback"
-    webOrigins:
-      - "https://ai.uds.dev"
-    hosted_domain: "uds.dev"
-
-  leapfrogai-api:
-    hosted_domain: "uds.dev"
+    domain: "uds.dev"
 
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev
     model: llama-cpp-python
-    supabase_url: https://supabase-kong.uds.dev
     disable_keycloak: false # If this package is deployed as a bundle, keycloak is assumed default
     supabase_anon_key: ''

--- a/uds-bundles/latest/gpu/uds-bundle.yaml
+++ b/uds-bundles/latest/gpu/uds-bundle.yaml
@@ -15,18 +15,6 @@ packages:
     # x-release-please-start-version
     ref: 0.8.0
     # x-release-please-end
-    overrides:
-      supabase:
-        supabase-secrets-generator:
-          variables:
-            - path: "leapfrogai.sso.redirectUris"
-              name: "KEYCLOAK_REDIRECT_URIS"
-              default:
-                - "https://supabase-kong.uds.dev/auth/v1/callback"
-            - path: "leapfrogai.sso.webOrigins"
-              name: KEYCLOAK_WEB_ORIGINS
-              default:
-                - "https://ai.uds.dev"
 
   # OpenAI-like API
   - name: leapfrogai-api

--- a/uds-bundles/latest/gpu/uds-config.yaml
+++ b/uds-bundles/latest/gpu/uds-config.yaml
@@ -11,19 +11,11 @@ variables:
     #tensor_parallel_size: 1   # TODO: reintroduce when vllm changes get pulled in
 
   supabase:
-    keycloak_redirect_uris:
-      - "https://supabase-kong.uds.dev/auth/v1/callback"
-    webOrigins:
-      - "https://ai.uds.dev"
-    hosted_domain: "uds.dev"
-
-  leapfrogai-api:
-    hosted_domain: "uds.dev"
+    domain: "uds.dev"
 
   leapfrogai-ui:
     subdomain: ai
     domain: uds.dev
     model: vllm
-    supabase_url: https://supabase-kong.uds.dev
     disable_keycloak: false # If this package is deployed as a bundle, keycloak is assumed default
     supabase_anon_key: ''


### PR DESCRIPTION
Some of our packages started to drift and duplicate the variables we used to declaring the domain name to use. This PR standardizes the variables to `DOMAIN` which also matches the name that other teams have been using for their UDS packages. This PR will simplify bundles and configuration.