### PR TITLE
fix: disable forceRun for supabase jwt generation

### DIFF
--- a/packages/supabase/bitnami-values-bootstrap.yaml
+++ b/packages/supabase/bitnami-values-bootstrap.yaml
@@ -25,7 +25,7 @@ jwt:
   autoGenerate:
     ## @param jwt.autoGenerate.forceRun Force the run of the JWT generation job
     ##
-    forceRun: true
+    forceRun: false
     ## @param jwt.autoGenerate.annotations [object] Add annotations to the job
     ##
     annotations:


### PR DESCRIPTION
The `forceRun=true` configuration was causing issues when performing an upgrade of the bitnami Supabase helm chart.