### PR TITLE
fix: k3d gpu deployment on headless and compute-only gpus

### DIFF
--- a/packages/k3d-gpu/plugin/device-plugin-daemonset.yaml
+++ b/packages/k3d-gpu/plugin/device-plugin-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
           - name: NVIDIA_VISIBLE_DEVICES
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
-            value: all
+            value: compute,utility
           - name: MPS_ROOT
             value: /run/nvidia/mps
         securityContext:


### PR DESCRIPTION
See issue for more details: https://github.com/defenseunicorns/leapfrogai/issues/834

Original fix implemented on:
- Ubuntu 22.04 Desktop (compute-only, and display) with RTX 40 series
- Ubuntu 22.04 Server (compute-only, and display) with H100s