### PR TITLE
chore: set kong service to default to ClusterIP

### DIFF
--- a/packages/supabase/bitnami-values.yaml
+++ b/packages/supabase/bitnami-values.yaml
@@ -167,6 +167,8 @@ kong:
       timeoutSeconds: 40
     readinessProbe:
       timeoutSeconds: 40
+  service:
+    type: ClusterIP
 postgresql:
   enabled: ###ZARF_VAR_ENABLE_POSTGRES###
   image:


### PR DESCRIPTION
The default value in the upstream chart is to set the Kong Service to `LoadBalancer` which is unnecessary for our deployment paradigm. Since we rely on UDS (and the Istio that it configures) for our ingress this PR changes the default value for this service to `ClusterIP`