### PR TITLE
fix: helm template evaluation for whisper GPU_REQUEST envvar

### DIFF
--- a/packages/whisper/chart/templates/deployment.yaml
+++ b/packages/whisper/chart/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           env:
             - name: GPU_REQUEST
-              value: "{{ (index .Values.resources.requests "nvidia.com/gpu") | default "0" }}"
+              value: "{{ (index .Values.resources.limits "nvidia.com/gpu") | default "0" }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
The helm template was checking the wrong value to determine if the `GPU_REQUEST` environment variable should be set. We are not seeing `.Values.resources.requests.nvidia.com/gpu`