### PR TITLE
fix(whisper): including missing cuda dependencies required for GPU runtimes

### DIFF
--- a/packages/whisper/Dockerfile
+++ b/packages/whisper/Dockerfile
@@ -20,7 +20,7 @@ RUN python -m pip wheel "packages/whisper[dev]" -w packages/whisper/build --find
 # download and covnert OpenAI's whisper base
 ARG MODEL_NAME=openai/whisper-base
 RUN pip install ctranslate2 transformers[torch] --no-index --find-links=packages/whisper/build/
-RUN ct2-transformers-converter --model ${MODEL_NAME} --output_dir .model --copy_files tokenizer.json --quantization float32
+RUN ct2-transformers-converter --model ${MODEL_NAME} --output_dir .model --copy_files tokenizer.json special_tokens_map.json preprocessor_config.json normalizer.json tokenizer_config.json vocab.json --quantization float32
 RUN pip uninstall -y ctranslate2 transformers[torch]
 
 RUN pip install packages/whisper/build/lfai_whisper*.whl --no-index --find-links=packages/whisper/build/

--- a/packages/whisper/pyproject.toml
+++ b/packages/whisper/pyproject.toml
@@ -9,6 +9,7 @@ version = "0.9.2"
 dependencies = [
     "faster-whisper == 1.0.3",
     "leapfrogai-sdk",
+    "openai-whisper == 20231117",
 ]
 requires-python = "~=3.11"
 readme = "README.md"


### PR DESCRIPTION
* Adds `preprocessor_config.json` to the copy step of the ctranslate2 conversion so that v3 whisper models have their feature dimensions read in properly. Without this there is a runtime error that occurs.
    * `weight of size [1280, 128, 3], expected input[1, 80, 3000] to have 128 channels, but got 80 channels instead`
* Adds `openai-whisper` as a dependency to fix a runtime error when running the backend via GPU
    * `Could not load library libcudnn_ops_infer.so.8. Error: libcudnn_ops_infer.so.8: cannot open shared object file: No such file or directory`