### PR TITLE
chore: update release workflow to install necessary python deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,10 @@ jobs:
         with:
           python-version-file: 'pyproject.toml'
 
+      - name: Instal Python Deps
+        run: |
+          python -m pip install ".[dev,dev-whisper,dev-vllm]"
+
       - name: Build and Publish k3d-gpu image
         run: |
           cd packages/k3d-gpu


### PR DESCRIPTION
This PR adds a step to the release workflow so that necessary Python libraries are installed. These python libraries are used when certain Zarf packages are built so that they can download the models from huggingface.