### PR TITLE
bug(ui): chat box jump and sidebar squishing 

### DIFF
--- a/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
+++ b/src/leapfrogai_ui/src/lib/components/ImportExport.svelte
@@ -47,6 +47,7 @@
         subtitle: `Threads are incorrectly formatted.`,
         timeout: 5000
       });
+      importing = false;
       return;
     }
     await threadsStore.importThreads(threads);

--- a/src/leapfrogai_ui/src/lib/components/LFSidebar.svelte
+++ b/src/leapfrogai_ui/src/lib/components/LFSidebar.svelte
@@ -55,7 +55,7 @@
 <!--Custom styling allows center SidebarGroup (chat threads) to scroll-->
 <Sidebar
   data-testid="sidebar"
-  class="sidebar-height flex border-r border-gray-700  dark:bg-gray-800 "
+  class="sidebar-height flex w-[255px] border-r border-gray-700  dark:bg-gray-800 "
 >
   <SidebarWrapper class="flex w-full flex-col px-0">
     <SidebarGroup>

--- a/src/leapfrogai_ui/src/lib/components/LFTextArea.svelte
+++ b/src/leapfrogai_ui/src/lib/components/LFTextArea.svelte
@@ -77,7 +77,7 @@ to a limit of maxRows. It can also show error text.
         return;
       }
 
-      const scrollHeight = ref.scrollHeight;
+      const scrollHeight = ref.scrollHeight + 2;
       const maxHeight = maxRows * 18; // Rows are 18px in height
       if (scrollHeight > maxHeight) {
         ref.style.height = `${maxHeight}px`;

--- a/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
+++ b/src/leapfrogai_ui/src/routes/chat/(dashboard)/[[thread_id]]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { beforeNavigate } from '$app/navigation';
-  import { PoweredByDU } from '$components';
+  import { LFTextArea, PoweredByDU } from '$components';
   import { Hr, ToolbarButton } from 'flowbite-svelte';
   import { onMount, tick } from 'svelte';
   import { threadsStore, toastStore } from '$stores';
@@ -24,7 +24,6 @@
   } from '$constants/toastMessages';
   import SelectAssistantDropdown from '$components/SelectAssistantDropdown.svelte';
   import { PaperPlaneOutline, StopOutline } from 'flowbite-svelte-icons';
-  import TextareaV2 from '$components/LFTextArea.svelte';
 
   export let data;
 
@@ -318,7 +317,7 @@
 
     <div class="flex items-end justify-around gap-2">
       <div class="flex flex-grow items-center rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-700">
-        <TextareaV2
+        <LFTextArea
           id="chat"
           data-testid="chat-input"
           class="mx-4 flex-grow resize-none bg-white dark:bg-gray-800"

--- a/src/leapfrogai_ui/tests/import_export.test.ts
+++ b/src/leapfrogai_ui/tests/import_export.test.ts
@@ -14,7 +14,9 @@ test('it can import and exports threads', async ({ page }) => {
     mimeType: 'application/JSON',
     buffer: Buffer.from(threadStr)
   });
+  await expect(page.getByText('Importing...')).toBeVisible();
   await expect(page.getByText(thread.metadata.label)).toHaveCount(1);
+  await expect(page.getByText('Importing...')).not.toBeVisible();
 
   const downloadPromise = page.waitForEvent('download');
   await page.getByText('Export chat history').click();

--- a/src/leapfrogai_ui/tests/import_export.test.ts
+++ b/src/leapfrogai_ui/tests/import_export.test.ts
@@ -42,3 +42,20 @@ test('it can import and exports threads', async ({ page }) => {
   // We can't test full equality because the ids and insertedAt dates will be different
   expect(importedThreads).toBeDefined();
 });
+
+test('it displays an error toast and removes the Importing spinner on error when the threads are improperly formatted', async ({
+  page
+}) => {
+  const threadStr = JSON.stringify([{ bad: 'data' }]);
+
+  await loadChatPage(page);
+
+  await page.getByTestId('import-chat-history-input').setInputFiles({
+    name: 'upload.json',
+    mimeType: 'application/JSON',
+    buffer: Buffer.from(threadStr)
+  });
+
+  await expect(page.getByText('Importing...')).not.toBeVisible();
+  await expect(page.getByText('Threads are incorrectly formatted.')).toBeVisible();
+});

--- a/src/leapfrogai_ui/tests/sidebar.test.ts
+++ b/src/leapfrogai_ui/tests/sidebar.test.ts
@@ -11,13 +11,14 @@ const newMessage1 = getSimpleMathQuestion();
 const newMessage2 = getSimpleMathQuestion();
 const newMessage3 = getSimpleMathQuestion();
 
-// TODO - check all playwright tests passing, then submit PR to a new branch called flowbite-integration
 test('it can delete threads', async ({ page }) => {
   await loadChatPage(page);
 
   const threadLocator = page.getByRole('button', { name: newMessage1 });
 
   await sendMessage(page, newMessage1);
+  await waitForResponseToComplete(page);
+
   await clickToDeleteThread(page, newMessage1);
   await expect(threadLocator).toHaveCount(0);
 });


### PR DESCRIPTION
closes #879 

Fixes chat input box pixel jump

Attempts to fix sidebar squish. I have not been able to replicate this issue or determine what caused it to only happen rarely. This fix sets a fixed width to the sidebar to hopefully prevent it in the future.

Fixes a minor test issue where messages were being sent and their thread deleted too fast resulting in an error in the backend logs. 

Fixes issue where "Importing..." spinner was not reset when there was an error importing conversations

