### PR TITLE
fix(api): message metadata default to {}

### DIFF
--- a/packages/api/supabase/migrations/20240808164500_v10.0.0_metadata_defaults.sql
+++ b/packages/api/supabase/migrations/20240808164500_v10.0.0_metadata_defaults.sql
@@ -1,0 +1,9 @@
+-- Update existing null metadata entries to '{}'
+UPDATE message_objects
+SET metadata = '{}'
+WHERE metadata IS NULL;
+
+-- Alter the metadata column to set a default value and make it non-null
+ALTER TABLE message_objects
+ALTER COLUMN metadata SET DEFAULT '{}',
+ALTER COLUMN metadata SET NOT NULL;


### PR DESCRIPTION
Updates the dbs `message_object` table to disallow null metadata and migrate any existing null metadata