### PR TITLE
fix(api) - Defaults to {} when none metadata is supplied

### DIFF
--- a/src/leapfrogai_api/data/crud_message.py
+++ b/src/leapfrogai_api/data/crud_message.py
@@ -10,3 +10,9 @@ class CRUDMessage(CRUDBase[Message]):
 
     def __init__(self, db: AsyncClient):
         super().__init__(db=db, model=Message, table_name="message_objects")
+
+    async def create(self, object_: Message) -> Message | None:
+        if object_.metadata is None:
+            object_.metadata = {}
+
+        return await super().create(object_)

--- a/src/leapfrogai_api/routers/openai/requests/create_message_request.py
+++ b/src/leapfrogai_api/routers/openai/requests/create_message_request.py
@@ -52,7 +52,7 @@ class CreateMessageRequest(BaseModel):
                 created_at=int(
                     time.time()
                 ),  # Leave blank to have Postgres generate a timestamp
-                metadata=self.metadata,
+                metadata=self.metadata or {},
                 object="thread.message",
                 role=self.role,
                 status="completed",

--- a/src/leapfrogai_api/routers/openai/requests/create_message_request.py
+++ b/src/leapfrogai_api/routers/openai/requests/create_message_request.py
@@ -52,7 +52,7 @@ class CreateMessageRequest(BaseModel):
                 created_at=int(
                     time.time()
                 ),  # Leave blank to have Postgres generate a timestamp
-                metadata=self.metadata or {},
+                metadata=self.metadata,
                 object="thread.message",
                 role=self.role,
                 status="completed",


### PR DESCRIPTION
Fixes `null` metadata in cases where `null` metadata is explicitly trying to be inserted into the db by replacing it before db insert.