### PR TITLE
test(e2e): move openai client to fixture

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from openai import OpenAI
+
+from .utils import create_test_user
+
+
+@pytest.fixture(scope="module")
+def client():
+    return OpenAI(
+        base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
+    )

--- a/tests/e2e/test_llama.py
+++ b/tests/e2e/test_llama.py
@@ -3,16 +3,10 @@ from pathlib import Path
 import pytest
 from openai import InternalServerError, OpenAI
 
-from .utils import create_test_user
-
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
-
 model_name = "llama-cpp-python"
 
 
-def test_chat_completions():
+def test_chat_completions(client: OpenAI):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is your name?"},
@@ -28,7 +22,7 @@ def test_chat_completions():
     assert len(chat_completion.choices[0].message.content) < 500
 
 
-def test_embeddings():
+def test_embeddings(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.embeddings.create(
             model=model_name,
@@ -37,7 +31,7 @@ def test_embeddings():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_transcriptions():
+def test_transcriptions(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.audio.transcriptions.create(
             model=model_name, file=Path("tests/data/0min12sec.wav")

--- a/tests/e2e/test_text_embeddings.py
+++ b/tests/e2e/test_text_embeddings.py
@@ -3,16 +3,10 @@ from pathlib import Path
 import pytest
 from openai import InternalServerError, OpenAI
 
-from .utils import create_test_user
-
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
-
 model_name = "text-embeddings"
 
 
-def test_completions():
+def test_completions(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.completions.create(
             model=model_name,
@@ -21,7 +15,7 @@ def test_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_chat_completions():
+def test_chat_completions(client: OpenAI):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "This should result in a failure"},
@@ -32,7 +26,7 @@ def test_chat_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_embeddings():
+def test_embeddings(client: OpenAI):
     embedding_response = client.embeddings.create(
         model=model_name,
         input="This should result in a failure",
@@ -44,7 +38,7 @@ def test_embeddings():
     assert len(embedding_response.data[0].embedding) < 1000
 
 
-def test_transcriptions():
+def test_transcriptions(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.audio.transcriptions.create(
             model=model_name, file=Path("tests/data/0min12sec.wav")

--- a/tests/e2e/test_whisper.py
+++ b/tests/e2e/test_whisper.py
@@ -5,14 +5,8 @@ import pytest
 from openai import InternalServerError, OpenAI
 import unicodedata
 
-from .utils import create_test_user
 
-client = OpenAI(
-    base_url="https://leapfrogai-api.uds.dev/openai/v1", api_key=create_test_user()
-)
-
-
-def test_completions():
+def test_completions(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.completions.create(
             model="whisper",
@@ -21,7 +15,7 @@ def test_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_chat_completions():
+def test_chat_completions(client: OpenAI):
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "This should result in a failure"},
@@ -32,7 +26,7 @@ def test_chat_completions():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_embeddings():
+def test_embeddings(client: OpenAI):
     with pytest.raises(InternalServerError) as excinfo:
         client.embeddings.create(
             model="whisper",
@@ -41,7 +35,7 @@ def test_embeddings():
     assert str(excinfo.value) == "Internal Server Error"
 
 
-def test_transcriptions():
+def test_transcriptions(client: OpenAI):
     transcription = client.audio.transcriptions.create(
         model="whisper",
         file=Path("tests/data/0min12sec.wav"),
@@ -56,7 +50,7 @@ def test_transcriptions():
     assert len(transcription.text) < 500, "The transcription should not be too long"
 
 
-def test_translations():
+def test_translations(client: OpenAI):
     translation = client.audio.translations.create(
         model="whisper",
         file=Path("tests/data/arabic-audio.wav"),

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,12 +1,10 @@
 import json
 import os
-
 import pytest
 import requests
 
 # This is the anon_key for supabase, it provides access to the endpoints that would otherwise be inaccessible
-ANON_KEY = os.environ["ANON_KEY"]
-
+ANON_KEY = os.getenv("ANON_KEY")
 DEFAULT_TEST_EMAIL = "fakeuser1@test.com"
 DEFAULT_TEST_PASSWORD = "password"
 


### PR DESCRIPTION
## Description

Test discovery in IDE can fail due to code that runs on dependency resolution. This code makes web requests to retrieve access tokens, but can fail due to a number of reasons. As a result, test discovery will fail and the IDE will not show correct information about your test functions, and will have many errors in the test Output log, making debugging other issues more difficult.

### CHANGES

This PR moves OpenAI client into a fixture that will only run once for each module. This will prevent the IDE from throwing errors on discovery.
