### PR TITLE
chore: pin python dependencies in root pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 dependencies = [ # Dev dependencies needed for all of LeapfrogAI
-    "openai == 1.31.1",
+    "openai == 1.32.1",
     "pip-tools == 7.3.0",
     "httpx == 0.27.2",
     "ruff == 0.4.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 dependencies = [ # Dev dependencies needed for all of LeapfrogAI
-    "openai",
+    "openai == 1.31.1",
     "pip-tools == 7.3.0",
-    "httpx",
-    "ruff",
-    "python-dotenv",
+    "httpx == 0.27.2",
+    "ruff == 0.4.3",
+    "python-dotenv == 1.0.1",
 ]
 requires-python = "~=3.11"
 
@@ -26,7 +26,7 @@ dev = [
     "requests",
     "requests-toolbelt",
     "pytest",
-    "huggingface_hub[cli,hf_transfer]",
+    "huggingface_hub[cli,hf_transfer] == 0.24.5",
 ]
 
 dev-whisper = ["ctranslate2 == 4.1.0", "transformers[torch] == 4.39.3"]


### PR DESCRIPTION
This PR pins the dependencies in the root pyproject.toml. This toml file is used in some of our workflows (such as e2e testing and release building) so it is important to have these deps pinned as we have for our other pyproject.tomls.