### PR TITLE
fix(vllm): initializes dictionary entry prior to usage

### DIFF
--- a/packages/vllm/src/main.py
+++ b/packages/vllm/src/main.py
@@ -178,22 +178,26 @@ class Model:
                 async for request_output in self.random_iterator:
                     request_id = request_output.request_id
 
-                    # Initialize dictionary entries
-                    if t0_by_id.get(request_id) is None:
-                        t0_by_id[request_id] = time.time()
-
-                    if index_by_id.get(request_id) is None:
-                        index_by_id[request_id] = 0
-
-                    if num_tokens_by_id.get(request_id) is None:
-                        num_tokens_by_id[request_id] = 0
-
-                    if request_output.finished:
+                    # At least one iteration must be done for each request_id
+                    if (
+                        self.delta_queue_by_id.get(request_id)
+                        and request_output.finished
+                    ):
                         # Signal that the "generate" function can stop waiting for additional inputs
                         logging.info(
                             f"Generated {num_tokens_by_id[request_id]} tokens in {time.time() - t0_by_id[request_id]:.2f}s"
                         )
                         self.done_by_id[request_id] = True
+                    else:
+                        # Initialize dictionary entries
+                        if t0_by_id.get(request_id) is None:
+                            t0_by_id[request_id] = time.time()
+
+                        if index_by_id.get(request_id) is None:
+                            index_by_id[request_id] = 0
+
+                        if num_tokens_by_id.get(request_id) is None:
+                            num_tokens_by_id[request_id] = 0
 
                     if (
                         request_output.outputs[0].text

--- a/packages/vllm/src/main.py
+++ b/packages/vllm/src/main.py
@@ -178,22 +178,22 @@ class Model:
                 async for request_output in self.random_iterator:
                     request_id = request_output.request_id
 
+                    # Initialize dictionary entries
+                    if t0_by_id.get(request_id) is None:
+                        t0_by_id[request_id] = time.time()
+
+                    if index_by_id.get(request_id) is None:
+                        index_by_id[request_id] = 0
+
+                    if num_tokens_by_id.get(request_id) is None:
+                        num_tokens_by_id[request_id] = 0
+
                     if request_output.finished:
                         # Signal that the "generate" function can stop waiting for additional inputs
                         logging.info(
                             f"Generated {num_tokens_by_id[request_id]} tokens in {time.time() - t0_by_id[request_id]:.2f}s"
                         )
                         self.done_by_id[request_id] = True
-                    else:
-                        # Initialize dictionary entries
-                        if t0_by_id.get(request_id) is None:
-                            t0_by_id[request_id] = time.time()
-
-                        if index_by_id.get(request_id) is None:
-                            index_by_id[request_id] = 0
-
-                        if num_tokens_by_id.get(request_id) is None:
-                            num_tokens_by_id[request_id] = 0
 
                     if (
                         request_output.outputs[0].text


### PR DESCRIPTION
## Description

Fixes exception occurring when the dictionary entry has not been instantiated before being referenced.

Exception:
```
│ leapfrogai-model Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                    │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/events.py", line 80, in _run                                                                                                                                                                                                                                                   │
│ leapfrogai-model     self._context.run(self._callback, *self._args)                                                                                                                                                                                                                                                                                                    │
│ leapfrogai-model   File "/home/leapfrogai/.venv/lib/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 38, in _raise_exception_on_finish                                                                                                                                                                                                                  │
│ leapfrogai-model     task.result()                                                                                                                                                                                                                                                                                                                                     │
│ leapfrogai-model   File "/home/leapfrogai/.venv/lib/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 508, in run_engine_loop                                                                                                                                                                                                                            │
│ leapfrogai-model     await asyncio.sleep(0)                                                                                                                                                                                                                                                                                                                            │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/tasks.py", line 640, in sleep                                                                                                                                                                                                                                                  │
│ leapfrogai-model     await __sleep0()                                                                                                                                                                                                                                                                                                                                  │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/tasks.py", line 634, in __sleep0                                                                                                                                                                                                                                               │
│ leapfrogai-model     yield                                                                                                                                                                                                                                                                                                                                             │
│ leapfrogai-model asyncio.exceptions.CancelledError                                                                                                                                                                                                                                                                                                                     │
│ leapfrogai-model Exception in thread Thread-2 (run):                                                                                                                                                                                                                                                                                                                   │
│ leapfrogai-model Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                    │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/threading.py", line 1045, in _bootstrap_inner                                                                                                                                                                                                                                          │
│ leapfrogai-model     self.run()                                                                                                                                                                                                                                                                                                                                        │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/threading.py", line 982, in run                                                                                                                                                                                                                                                        │
│ leapfrogai-model     self._target(*self._args, **self._kwargs)                                                                                                                                                                                                                                                                                                         │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/runners.py", line 190, in run                                                                                                                                                                                                                                                  │
│ leapfrogai-model     return runner.run(main)                                                                                                                                                                                                                                                                                                                           │
│ leapfrogai-model            ^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                                           │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/runners.py", line 118, in run                                                                                                                                                                                                                                                  │
│ leapfrogai-model     return self._loop.run_until_complete(task)                                                                                                                                                                                                                                                                                                        │
│ leapfrogai-model            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                        │
│ leapfrogai-model   File "/home/leapfrogai/.pyenv/versions/3.11.6/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete                                                                                                                                                                                                                               │
│ leapfrogai-model     return future.result()                                                                                                                                                                                                                                                                                                                            │
│ leapfrogai-model            ^^^^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                                            │
│ leapfrogai-model   File "/home/leapfrogai/src/main.py", line 184, in iterate_outputs                                                                                                                                                                                                                                                                                   │
│ leapfrogai-model     f"Generated {num_tokens_by_id[request_id]} tokens in {time.time() - t0_by_id[request_id]:.2f}s"                                                                                                                                                                                                                                                   │
│ leapfrogai-model                  ~~~~~~~~~~~~~~~~^^^^^^^^^^^^                                                                                                                                                                                                                                                                                                         │
│ leapfrogai-model KeyError: 'e6271f2482fb48a181a2ee79c871b3df'
```

### BREAKING CHANGES

### CHANGES

* Prevents vllm from reaching a `finished` state without first initializing the token count and text delta.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
