### PR TITLE
docs: fixed command on Quick Start page (Building the UDS Bundle) docs

### DIFF
--- a/website/content/en/docs/local-deploy-guide/quick_start.md
+++ b/website/content/en/docs/local-deploy-guide/quick_start.md
@@ -48,12 +48,12 @@ If you already have a pre-built UDS bundle, please skip to [Deploying the UDS Bu
 
     ```bash
     # For CPU-only
-    cd bundles/latest/cpu/
+    cd uds-bundles/latest/cpu/
     uds create .
     UDS_ARCH=amd64 uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
 
     # For compatible AMD64, NVIDIA CUDA-capable GPU machines
-    cd bundles/latest/gpu/
+    cd uds-bundles/latest/gpu/
     uds create .
     UDS_ARCH=amd64 uds deploy uds-bundle-leapfrogai-*.tar.zst --confirm
     ```


### PR DESCRIPTION
## Description
This fixes the `cd` command in the quick start docs.

### BREAKING CHANGES
N/A

### CHANGES
Modified `website/content/en/docs/local-deploy-guide/quick_start.md` with correct command.

## Related Issue

Relates to   #961 

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
