### PR TITLE
fix(ui): csp prevents iframe content from showing

### DIFF
--- a/src/leapfrogai_ui/src/hooks.server.ts
+++ b/src/leapfrogai_ui/src/hooks.server.ts
@@ -103,7 +103,8 @@ const csp: Handle = async ({ event, resolve }) => {
       process.env.PUBLIC_SUPABASE_URL,
       process.env.SUPABASE_AUTH_EXTERNAL_KEYCLOAK_URL
     ],
-    'child-src': ["'none'"], // note - this will break the annotations story and will need to updated to allow the correct resource
+    'child-src': ["'none'"],
+    'frame-src': [`blob: 'self'`],
     'frame-ancestors': ["'none'"]
   };
 


### PR DESCRIPTION
When viewing a document from a RAG annotation, the content in the iframe was blocked by CSP.