### PR TITLE
fix: correct fsGroup configuration in various deployments

### DIFF
--- a/packages/api/chart/templates/api/deployment.yaml
+++ b/packages/api/chart/templates/api/deployment.yaml
@@ -72,7 +72,6 @@ spec:
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
-            fsGroup: 65532
           volumeMounts:
           - name: api-model
             mountPath: /config

--- a/packages/api/chart/templates/migration-job.yaml
+++ b/packages/api/chart/templates/migration-job.yaml
@@ -31,6 +31,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.image.securityContext.runAsUser }}
           runAsGroup: {{ .Values.image.securityContext.runAsGroup }}
-          fsGroup: {{ .Values.image.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.image.securityContext.fsGroup }}
       restartPolicy: Never
   backoffLimit: 4

--- a/packages/llama-cpp-python/chart/templates/deployment.yaml
+++ b/packages/llama-cpp-python/chart/templates/deployment.yaml
@@ -33,7 +33,6 @@ spec:
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
-            fsGroup: 65532
           # This command looks for the Zarf "data injection marker" which is a timestamped file that is injected after everything else and marks the injection as complete.
           command:
             [

--- a/packages/llama-cpp-python/chart/values.yaml
+++ b/packages/llama-cpp-python/chart/values.yaml
@@ -19,11 +19,11 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 65532
 
 securityContext:
   runAsUser: 65532
   runAsGroup: 65532
-  fsGroup: 65532
 
 service:
   type: ClusterIP

--- a/packages/repeater/chart/values.yaml
+++ b/packages/repeater/chart/values.yaml
@@ -19,11 +19,11 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 65532
 
 securityContext:
   runAsUser: 65532
   runAsGroup: 65532
-  fsGroup: 65532
 
 service:
   type: ClusterIP

--- a/packages/supabase/migrationChart/templates/migration-job.yaml
+++ b/packages/supabase/migrationChart/templates/migration-job.yaml
@@ -31,6 +31,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.leapfrogai.securityContext.runAsUser }}
           runAsGroup: {{ .Values.leapfrogai.securityContext.runAsGroup }}
-          fsGroup: {{ .Values.leapfrogai.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.leapfrogai.securityContext.fsGroup }}
       restartPolicy: Never
   backoffLimit: 4

--- a/packages/text-embeddings/chart/templates/deployment.yaml
+++ b/packages/text-embeddings/chart/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
-            fsGroup: 65532
           # This command looks for the Zarf "data injection marker" which is a timestamped file that is injected after everything else and marks the injection as complete.
           command:
             [

--- a/packages/text-embeddings/chart/values.yaml
+++ b/packages/text-embeddings/chart/values.yaml
@@ -19,11 +19,11 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 65532
 
 securityContext:
   runAsUser: 65532
   runAsGroup: 65532
-  fsGroup: 65532
 
 service:
   type: ClusterIP

--- a/packages/ui/chart/templates/ui/migration-job.yaml
+++ b/packages/ui/chart/templates/ui/migration-job.yaml
@@ -31,6 +31,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.image.securityContext.runAsUser }}
           runAsGroup: {{ .Values.image.securityContext.runAsGroup }}
-          fsGroup: {{ .Values.image.securityContext.fsGroup }}
+      securityContext:
+        fsGroup: {{ .Values.image.securityContext.fsGroup }}
       restartPolicy: Never
   backoffLimit: 4

--- a/packages/vllm/chart/templates/deployment.yaml
+++ b/packages/vllm/chart/templates/deployment.yaml
@@ -34,7 +34,6 @@ spec:
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
-            fsGroup: 65532
           # This command looks for the Zarf "data injection marker" which is a timestamped file that is injected after everything else and marks the injection as complete.
           command:
             [

--- a/packages/vllm/chart/values.yaml
+++ b/packages/vllm/chart/values.yaml
@@ -19,11 +19,11 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 65532
 
 securityContext:
   runAsUser: 65532
   runAsGroup: 65532
-  fsGroup: 65532
 
 service:
   type: ClusterIP

--- a/packages/whisper/chart/templates/deployment.yaml
+++ b/packages/whisper/chart/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           securityContext:
             runAsUser: 65532
             runAsGroup: 65532
-            fsGroup: 65532
           # This command looks for the Zarf "data injection marker" which is a timestamped file that is injected after everything else and marks the injection as complete.
           command:
             [

--- a/packages/whisper/chart/values.yaml
+++ b/packages/whisper/chart/values.yaml
@@ -19,11 +19,11 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  fsGroup: 65532
 
 securityContext:
   runAsUser: 65532
   runAsGroup: 65532
-  fsGroup: 65532
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Several (if not all 😬) of our deployments had the `fsGroup` configuration in the wrong place so it wasn't actually applying. This led to an issue where our data-injections were not working when the underlying store was not a PVC provisioned with `local-path` as the StorageClass.


This PR fixes the fsGroup key so that it is in the correct place.