### PR TITLE
chore(ui): add test for assistant with no files

### DIFF
--- a/src/leapfrogai_ui/tests/chat.test.ts
+++ b/src/leapfrogai_ui/tests/chat.test.ts
@@ -190,6 +190,7 @@ test('it shows a loading skeleton when a response is pending', async ({ page, op
 
 test('it can chat with an assistant that doesnt have files', async ({ page, openAIClient }) => {
   const assistant = await createAssistantWithApi({ openAIClient });
+  expect(assistant.tool_resources?.file_search).not.toBeDefined(); // ensure the assistant has no files
 
   await loadChatPage(page);
 

--- a/src/leapfrogai_ui/tests/chat.test.ts
+++ b/src/leapfrogai_ui/tests/chat.test.ts
@@ -164,6 +164,7 @@ test('it formats code in a code block and can copy the code', async ({ page }) =
 });
 
 // The skeleton only shows for assistant messages
+// TODO -this test can be flaky if the backend is really fast and the loading-msg skeleton barely has time to be shown
 test('it shows a loading skeleton when a response is pending', async ({ page, openAIClient }) => {
   const assistant = await createAssistantWithApi({ openAIClient });
 
@@ -181,6 +182,27 @@ test('it shows a loading skeleton when a response is pending', async ({ page, op
   await waitForResponseToComplete(page);
   await expect(messages).toHaveCount(2);
   await expect(page.getByTestId('loading-msg')).not.toBeVisible();
+
+  // Cleanup
+  await deleteActiveThread(page, openAIClient);
+  await deleteAssistantWithApi(assistant.id, openAIClient);
+});
+
+test('it can chat with an assistant that doesnt have files', async ({ page, openAIClient }) => {
+  const assistant = await createAssistantWithApi({ openAIClient });
+
+  await loadChatPage(page);
+
+  // Select assistant
+  await expect(page.getByTestId('assistants-select-btn')).not.toBeDisabled();
+  const assistantDropdown = page.getByTestId('assistants-select-btn');
+  await assistantDropdown.click();
+  await page.getByText(assistant!.name!).click();
+
+  const messages = page.getByTestId('message');
+  await sendMessage(page, newMessage1);
+  await waitForResponseToComplete(page);
+  await expect(messages).toHaveCount(2);
 
   // Cleanup
   await deleteActiveThread(page, openAIClient);


### PR DESCRIPTION
Adds an E2E test for chatting with an assistant without files. 
Also added todo comment for the test above it which can be flaky when our backend is getting an assistant response really fast. 

This test does not yet run in the workflow. It also depends on #995 