### PR TITLE
chore(test): prevent E2E tests from running in draft PRs

### DIFF
--- a/.github/workflows/e2e-registry1-weekly.yaml
+++ b/.github/workflows/e2e-registry1-weekly.yaml
@@ -27,6 +27,7 @@ jobs:
   test-flavors:
     runs-on: ai-ubuntu-big-boy-8-core
     name: e2e_registry1_weekly
+    if: ${{ !github.event.pull_request.draft }}
 
     permissions:
       contents: read

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -76,6 +76,7 @@ jobs:
 
   integration:
     runs-on: ai-ubuntu-big-boy-8-core
+    if: ${{ !github.event.pull_request.draft }}
 
     # If basic unit tests fail, do not run this job
     needs: pytest


### PR DESCRIPTION
## Description

Prevents E2E tests from running on draft PRs.

### BREAKING CHANGES

N/A

### CHANGES

- Disables E2E that used paid large runners from running on draft PRs

## Related Issue

N/A

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
