### PR TITLE
fix: exclude registry1 weekly from release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -45,11 +45,6 @@
           "type": "generic",
           "path": "**/hugo.toml",
           "glob": true
-        },
-        {
-          "type": "generic",
-          "path": ".github/workflows/e2e-registry1-weekly.yaml",
-          "glob": true
         }
       ]
     }


### PR DESCRIPTION
## Description

This PR removes the Registry1 Weekly from release-please configuration to fix the failing tag workflow.

Release-please configuration does not gracefully handle files that do not have the identifier for updating versions if they are included in the release-please configuration as a target. The release-please identifier for Registry1 Weekly was removed due to the `v0.12.2` branch not containing the correct refs and code for running the Registry1 weekly test. The commit hash in the Registry1 weekly currently points to a commit after `v0.12.2` so that the Registry1 weekly tests run properly, hence why the release-please identifier was removed from the workflow file. In the future, renovate will automate the Registry1 weekly updates and not release-please.


## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
