### PR TITLE
chore(api): update langchain to 0.2.12

### DIFF
--- a/src/leapfrogai_api/pyproject.toml
+++ b/src/leapfrogai_api/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "watchfiles == 0.21.0",
     "leapfrogai_sdk",
     "supabase == 2.6.0",
-    "langchain == 0.2.11",
+    "langchain == 0.2.12",
     "langchain-community == 0.2.11",
     "unstructured[md,xlsx,pptx] == 0.15.9", # Only specify necessary filetypes to prevent package bloat (e.g. 130MB vs 6GB)
     "nltk == 3.9.1",                        # Required for pickled code containing .pptx parsing dependencies

--- a/src/leapfrogai_api/pyproject.toml
+++ b/src/leapfrogai_api/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "watchfiles == 0.21.0",
     "leapfrogai_sdk",
     "supabase == 2.6.0",
-    "langchain == 0.2.1",
-    "langchain-community == 0.2.1",
+    "langchain == 0.2.11",
+    "langchain-community == 0.2.11",
     "unstructured[md,xlsx,pptx] == 0.15.9", # Only specify necessary filetypes to prevent package bloat (e.g. 130MB vs 6GB)
     "nltk == 3.9.1",                        # Required for pickled code containing .pptx parsing dependencies
     "pylibmagic == 0.5.0",                  # Resolves issue with libmagic not being bundled with OS - https://github.com/ahupp/python-magic/issues/233, may not be needed after this is merged https://github.com/ahupp/python-magic/pull/294


### PR DESCRIPTION
## Description

Langchain <=0.2.12 contains a CVE that has no workaround besides updating the dependency.

Scan Report: https://vat.dso.mil/vat/image?imageName=opensource/defenseunicorns/leapfrogai/api&tag=v0.12.2&branch=master for details.

Vulnerability: [CVE-2024-5998](https://vat.dso.mil/vat/finding?name=CVE-2024-5998)

### BREAKING CHANGES

N/A

### CHANGES

- updates langchain to 0.2.12 and langchain-community to 0.2.11
  - noted required follow-up changes to be made in cross-stream registry1 image: https://repo1.dso.mil/dsop/opensource/defenseunicorns/leapfrogai/api/-/issues/19#note_2518234

## Related Issue

Fixes #1047

Relates to: https://repo1.dso.mil/dsop/opensource/defenseunicorns/leapfrogai/api/-/issues/19

## Checklist before merging

- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
