### PR TITLE
chore: variablize uds distro for uds make target

### DIFF
--- a/packages/k3d-gpu/Makefile
+++ b/packages/k3d-gpu/Makefile
@@ -1,6 +1,6 @@
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-UDS_VERSION := 0.25.0
+UDS_VERSION := k3d-core-slim-dev:0.27.1
 LOCAL_VERSION ?= $(shell git rev-parse --short HEAD)
 DOCKER_FLAGS :=
 ZARF_FLAGS :=
@@ -13,13 +13,13 @@ build-k3d-gpu:
 	-t ghcr.io/defenseunicorns/leapfrogai/k3d-gpu:${LOCAL_VERSION} .
 
 create-uds-gpu-cluster: build-k3d-gpu
-	@uds deploy k3d-core-slim-dev:${UDS_VERSION} \
+	@uds deploy ${UDS_VERSION} \
 	${ZARF_FLAGS} \
 	--set K3D_EXTRA_ARGS="--gpus=all \
 	--image=ghcr.io/defenseunicorns/leapfrogai/k3d-gpu:${LOCAL_VERSION}" --confirm
 
 create-uds-cpu-cluster:
-	@uds deploy k3d-core-slim-dev:${UDS_VERSION} \
+	@uds deploy ${UDS_VERSION} \
 	${ZARF_FLAGS} \
 	--confirm
 

--- a/packages/k3d-gpu/Makefile
+++ b/packages/k3d-gpu/Makefile
@@ -1,6 +1,6 @@
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-UDS_VERSION := k3d-core-slim-dev:0.27.1
+UDS_VERSION := k3d-core-slim-dev:0.26.1
 LOCAL_VERSION ?= $(shell git rev-parse --short HEAD)
 DOCKER_FLAGS :=
 ZARF_FLAGS :=


### PR DESCRIPTION
## Description

This will make it easier to override the distro of UDS core when using the make targets to create a new cluster.

### BREAKING CHANGES

None

### CHANGES

* Update UDS core version to 0.26.1 in make target
* UDS_VERSION is now the entire distro/version (i.e. `uds-core-slim-dev:0.27.1`) in Makefile

## Related Issue

None

## Checklist before merging

- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
