### PR TITLE
fix(api, tests): configmap reloading core dump

### DIFF
--- a/packages/vllm/Dockerfile
+++ b/packages/vllm/Dockerfile
@@ -6,7 +6,7 @@ FROM nvidia/cuda:12.2.2-devel-ubuntu22.04 AS builder
 # set SDK location
 # set the pyenv and Python versions
 ARG SDK_DEST=src/leapfrogai_sdk/build \
-    PYTHON_VERSION=3.11.9 \
+    PYTHON_VERSION=3.11.6 \
     PYENV_GIT_TAG=v2.4.8
 
 # use root user for deps installation and nonroot user creation
@@ -54,10 +54,10 @@ RUN curl https://pyenv.run | bash && \
 ENV PYENV_ROOT="/home/nonroot/.pyenv" \
     PATH="/home/nonroot/.pyenv/bin:$PATH"
 
-# Install Python, set it as global, and create a venv
+# Install Python 3.11.6, set it as global, and create a venv
 RUN . ~/.bashrc && \
-    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} && \
-    pyenv global ${PYTHON_VERSION} && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.6 && \
+    pyenv global 3.11.6 && \
     pyenv exec python -m venv .venv
 
 # set path to venv python
@@ -101,7 +101,7 @@ COPY --from=sdk --chown=nonroot:nonroot /leapfrogai/${SDK_DEST} ./${SDK_DEST}
 COPY --from=builder --chown=nonroot:nonroot /home/leapfrogai/.venv /home/leapfrogai/.venv
 COPY --from=builder --chown=nonroot:nonroot /home/leapfrogai/packages/vllm/src /home/leapfrogai/packages/vllm/src
 # copy-in python binaries
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.pyenv/versions/${PYTHON_VERSION}/ /home/nonroot/.pyenv/versions/${PYTHON_VERSION}/
+COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.pyenv/versions/3.11.6/ /home/nonroot/.pyenv/versions/3.11.6/
 
 # load ARG values into env variables for pickup by confz
 ENV LAI_HF_HUB_ENABLE_HF_TRANSFER=${HF_HUB_ENABLE_HF_TRANSFER} \

--- a/packages/vllm/Dockerfile
+++ b/packages/vllm/Dockerfile
@@ -6,7 +6,7 @@ FROM nvidia/cuda:12.2.2-devel-ubuntu22.04 AS builder
 # set SDK location
 # set the pyenv and Python versions
 ARG SDK_DEST=src/leapfrogai_sdk/build \
-    PYTHON_VERSION=3.11.6 \
+    PYTHON_VERSION=3.11.9 \
     PYENV_GIT_TAG=v2.4.8
 
 # use root user for deps installation and nonroot user creation
@@ -54,10 +54,10 @@ RUN curl https://pyenv.run | bash && \
 ENV PYENV_ROOT="/home/nonroot/.pyenv" \
     PATH="/home/nonroot/.pyenv/bin:$PATH"
 
-# Install Python 3.11.6, set it as global, and create a venv
+# Install Python, set it as global, and create a venv
 RUN . ~/.bashrc && \
-    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11.6 && \
-    pyenv global 3.11.6 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION} && \
+    pyenv global ${PYTHON_VERSION} && \
     pyenv exec python -m venv .venv
 
 # set path to venv python
@@ -101,7 +101,7 @@ COPY --from=sdk --chown=nonroot:nonroot /leapfrogai/${SDK_DEST} ./${SDK_DEST}
 COPY --from=builder --chown=nonroot:nonroot /home/leapfrogai/.venv /home/leapfrogai/.venv
 COPY --from=builder --chown=nonroot:nonroot /home/leapfrogai/packages/vllm/src /home/leapfrogai/packages/vllm/src
 # copy-in python binaries
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.pyenv/versions/3.11.6/ /home/nonroot/.pyenv/versions/3.11.6/
+COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.pyenv/versions/${PYTHON_VERSION}/ /home/nonroot/.pyenv/versions/${PYTHON_VERSION}/
 
 # load ARG values into env variables for pickup by confz
 ENV LAI_HF_HUB_ENABLE_HF_TRANSFER=${HF_HUB_ENABLE_HF_TRANSFER} \

--- a/src/leapfrogai_api/pyproject.toml
+++ b/src/leapfrogai_api/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "uvicorn == 0.23.2",
     "docx2txt == 0.8",
     "python-multipart == 0.0.7",            #indirect dep of FastAPI to receive form data for file uploads
-    "watchfiles == 0.21.0",
+    "watchdog",
     "leapfrogai_sdk",
     "supabase == 2.6.0",
     "langchain == 0.2.12",

--- a/src/leapfrogai_api/pyproject.toml
+++ b/src/leapfrogai_api/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "uvicorn == 0.23.2",
     "docx2txt == 0.8",
     "python-multipart == 0.0.7",            #indirect dep of FastAPI to receive form data for file uploads
-    "watchdog",
+    "watchdog == 5.0.2",
     "leapfrogai_sdk",
     "supabase == 2.6.0",
     "langchain == 0.2.12",

--- a/src/leapfrogai_api/utils/config.py
+++ b/src/leapfrogai_api/utils/config.py
@@ -145,18 +145,20 @@ class Config:
         return self.models.get(model)
 
     def parse_models(self, loaded_artifact, config_file):
-        for m in loaded_artifact.get("models", []):
+        for m in loaded_artifact["models"]:
             model_config = Model(name=m["name"], backend=m["backend"])
 
             self.models[m["name"]] = model_config
-            self.config_sources.setdefault(config_file, []).append(m["name"])
-            logger.info(f"Added {m['name']} to model config")
+            try:
+                self.config_sources[config_file].append(m["name"])
+            except KeyError:
+                self.config_sources[config_file] = [m["name"]]
+            logger.info("added {} to model config".format(m["name"]))
 
     def remove_model_by_config(self, config_file):
-        model_names = self.config_sources.get(config_file, [])
-        for model_name in model_names:
-            self.models.pop(model_name, None)
-            logger.info(f"Removed {model_name} from model config")
+        for model_name in self.config_sources[config_file]:
+            self.models.pop(model_name)
+            logger.info("removed {} from model config".format(model_name))
 
-        # Clear config once all corresponding models are deleted
-        self.config_sources.pop(config_file, None)
+        # clear config once all corresponding models are deleted
+        self.config_sources.pop(config_file)

--- a/src/leapfrogai_api/utils/config.py
+++ b/src/leapfrogai_api/utils/config.py
@@ -33,12 +33,17 @@ class ConfigHandler(FileSystemEventHandler):
             return
 
         filename = os.path.basename(event.src_path)
+        logger.debug(f"Processing event '{event.event_type}' for file '{filename}'")
 
         # Check if the file matches the config filename or pattern
         if fnmatch.fnmatch(filename, self.config.filename):
             if event.event_type == "deleted":
+                logger.info(f"Detected deletion of config file '{filename}'")
                 self.config.remove_model_by_config(filename)
             else:
+                logger.info(
+                    f"Detected modification/creation of config file '{filename}'"
+                )
                 self.config.load_config_file(self.config.directory, filename)
 
 

--- a/src/leapfrogai_api/utils/config.py
+++ b/src/leapfrogai_api/utils/config.py
@@ -1,15 +1,45 @@
+import asyncio
 import fnmatch
 import glob
 import logging
 import os
 import toml
 import yaml
-from watchfiles import Change, awatch
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 from leapfrogai_api.typedef.models import Model
 
-
 logger = logging.getLogger(__name__)
+
+
+class ConfigHandler(FileSystemEventHandler):
+    def __init__(self, config):
+        self.config = config
+        super().__init__()
+
+    def on_created(self, event):
+        self.process(event)
+
+    def on_modified(self, event):
+        self.process(event)
+
+    def on_deleted(self, event):
+        self.process(event)
+
+    def process(self, event):
+        # Ignore directory events
+        if event.is_directory:
+            return
+
+        filename = os.path.basename(event.src_path)
+
+        # Check if the file matches the config filename or pattern
+        if fnmatch.fnmatch(filename, self.config.filename):
+            if event.event_type == "deleted":
+                self.config.remove_model_by_config(filename)
+            else:
+                self.config.load_config_file(self.config.directory, filename)
 
 
 class Config:
@@ -21,6 +51,8 @@ class Config:
     ):
         self.models = models
         self.config_sources = config_sources
+        self.directory = "."
+        self.filename = "config.yaml"
 
     def __str__(self):
         return f"Models: {self.models}"
@@ -28,82 +60,74 @@ class Config:
     async def watch_and_load_configs(self, directory=".", filename="config.yaml"):
         # Get the config directory and filename from the environment variables if provided
         env_directory = os.environ.get("LFAI_CONFIG_PATH", directory)
-        if env_directory is not None and env_directory != "":
+        if env_directory:
             directory = env_directory
         env_filename = os.environ.get("LFAI_CONFIG_FILENAME", filename)
-        if env_filename is not None and env_filename != "":
+        if env_filename:
             filename = env_filename
+
+        self.directory = directory
+        self.filename = filename
 
         # Process all the configs that were already in the directory
         self.load_all_configs(directory, filename)
 
-        # Watch the directory for changes until the end of time
-        while True:
-            async for changes in awatch(directory, recursive=False, step=50):
-                # get two unique lists of files that have been (updated files and deleted files)
-                # (awatch can return duplicates depending on the type of updates that happen)
-                logger.info("Config changes detected: {}".format(changes))
-                unique_new_files = set()
-                unique_deleted_files = set()
-                for change in changes:
-                    if change[0] == Change.deleted:
-                        unique_deleted_files.add(os.path.basename(change[1]))
-                    else:
-                        unique_new_files.add(os.path.basename(change[1]))
+        # Set up the event handler and observer
+        event_handler = ConfigHandler(self)
+        observer = Observer()
+        observer.schedule(event_handler, path=directory, recursive=False)
 
-                # filter the files to those that match the filename or glob pattern
-                filtered_new_matches = fnmatch.filter(unique_new_files, filename)
-                filtered_deleted_matches = fnmatch.filter(
-                    unique_deleted_files, filename
-                )
+        # Start the observer
+        observer.start()
+        logger.info(f"Started watching directory: {directory}")
 
-                # load all the updated config files
-                for match in filtered_new_matches:
-                    self.load_config_file(directory, match)
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            # Stop the observer if the script is interrupted
+            observer.stop()
+            logger.info(f"Stopped watching directory: {directory}")
 
-                # remove deleted models
-                for match in filtered_deleted_matches:
-                    self.remove_model_by_config(match)
+        # Wait for the observer to finish
+        observer.join()
 
     async def clear_all_models(self):
-        # reset the model config on shutdown (so old model configs don't get cached)
+        # Reset the model config on shutdown (so old model configs don't get cached)
         self.models = {}
         self.config_sources = {}
         logger.info("All models have been removed")
 
     def load_config_file(self, directory: str, config_file: str):
-        logger.info("Loading config file: {}/{}".format(directory, config_file))
+        logger.info(f"Loading config file: {directory}/{config_file}")
 
-        # load the config file into the config object
+        # Load the config file into the config object
         config_path = os.path.join(directory, config_file)
-        with open(config_path) as c:
-            # Load the file into a python object
-            loaded_artifact = {}
-            if config_path.endswith(".toml"):
-                loaded_artifact = toml.load(c)
-            elif config_path.endswith(".yaml"):
-                loaded_artifact = yaml.safe_load(c)
-            else:
-                # TODO: Return an error ???
-                logger.error(f"Unsupported file type: {config_path}")
-                return
+        try:
+            with open(config_path) as c:
+                # Load the file into a python object
+                if config_path.endswith(".toml"):
+                    loaded_artifact = toml.load(c)
+                elif config_path.endswith(".yaml"):
+                    loaded_artifact = yaml.safe_load(c)
+                else:
+                    logger.error(f"Unsupported file type: {config_path}")
+                    return
 
-            # parse the object into our config
-            self.parse_models(loaded_artifact, config_file)
+                # Parse the object into our config
+                self.parse_models(loaded_artifact, config_file)
 
-        logger.info("loaded artifact at {}".format(config_path))
-
-        return
+            logger.info(f"Loaded artifact at {config_path}")
+        except Exception as e:
+            logger.error(f"Failed to load config file {config_path}: {e}")
 
     def load_all_configs(self, directory="", filename="config.yaml"):
         logger.info(
-            "Loading all configs in {} that match the name '{}'".format(
-                directory, filename
-            )
+            f"Loading all configs in {directory} that match the name '{filename}'"
         )
 
         if not os.path.exists(directory):
-            logger.error("The config directory ({}) does not exist".format(directory))
+            logger.error(f"The config directory ({directory}) does not exist")
             return "THE CONFIG DIRECTORY DOES NOT EXIST"
 
         # Get all config files and load them into the config object
@@ -112,29 +136,22 @@ class Config:
             dir_path, file_path = os.path.split(config_path)
             self.load_config_file(directory=dir_path, config_file=file_path)
 
-        return
-
     def get_model_backend(self, model: str) -> Model | None:
-        if model in self.models:
-            return self.models[model]
-        else:
-            return None
+        return self.models.get(model)
 
     def parse_models(self, loaded_artifact, config_file):
-        for m in loaded_artifact["models"]:
+        for m in loaded_artifact.get("models", []):
             model_config = Model(name=m["name"], backend=m["backend"])
 
             self.models[m["name"]] = model_config
-            try:
-                self.config_sources[config_file].append(m["name"])
-            except KeyError:
-                self.config_sources[config_file] = [m["name"]]
-            logger.info("added {} to model config".format(m["name"]))
+            self.config_sources.setdefault(config_file, []).append(m["name"])
+            logger.info(f"Added {m['name']} to model config")
 
     def remove_model_by_config(self, config_file):
-        for model_name in self.config_sources[config_file]:
-            self.models.pop(model_name)
-            logger.info("removed {} from model config".format(model_name))
+        model_names = self.config_sources.get(config_file, [])
+        for model_name in model_names:
+            self.models.pop(model_name, None)
+            logger.info(f"Removed {model_name} from model config")
 
-        # clear config once all corresponding models are deleted
-        self.config_sources.pop(config_file)
+        # Clear config once all corresponding models are deleted
+        self.config_sources.pop(config_file, None)

--- a/tests/pytest/leapfrogai_api/test_api.py
+++ b/tests/pytest/leapfrogai_api/test_api.py
@@ -96,15 +96,10 @@ def test_config_delete(tmp_path):
         response = client.get("/leapfrogai/v1/models")
         assert response.status_code == 200
 
-        # assert response.json() == {
-        #    "config_sources": {"repeater-test-config.yaml": [MODEL]},
-        #    "models": {MODEL: {"backend": "localhost:50051", "name": MODEL}},
-        # }
-
         expected_response = {
             "config_sources": {"repeater-test-config.yaml": [MODEL]},
             "models": {MODEL: {"backend": "localhost:50051", "name": MODEL}},
-            "directory": LFAI_CONFIG_PATH,
+            "directory": os.environ["LFAI_CONFIG_PATH"],
             "filename": LFAI_CONFIG_FILENAME,
         }
         assert response.json() == expected_response
@@ -121,7 +116,7 @@ def test_config_delete(tmp_path):
         expected_empty_response = {
             "config_sources": {},
             "models": {},
-            "directory": LFAI_CONFIG_PATH,
+            "directory": os.environ["LFAI_CONFIG_PATH"],
             "filename": LFAI_CONFIG_FILENAME,
         }
         assert response.json() == expected_empty_response

--- a/tests/pytest/leapfrogai_api/test_api.py
+++ b/tests/pytest/leapfrogai_api/test_api.py
@@ -24,6 +24,12 @@ LFAI_CONFIG_PATH = os.environ["LFAI_CONFIG_PATH"] = os.path.join(
 )
 LFAI_CONFIG_FILEPATH = os.path.join(LFAI_CONFIG_PATH, LFAI_CONFIG_FILENAME)
 
+MODEL = "repeater"
+TEXT_INPUT = (
+    "This is the input content for completions, embeddings, and chat completions"
+)
+TEXT_INPUT_LEN = len(TEXT_INPUT)
+
 
 #########################
 #########################


### PR DESCRIPTION
## Description
* Replaces [watchfiles](https://pypi.org/project/watchfiles/) with [watchdog](https://pypi.org/project/watchdog/) to deal with the coredump issue being caused by a combination of `awatch`, `asyncio` and test code that is sensitive to async activity.
* Fixes pipeline issue here: https://github.com/defenseunicorns/leapfrogai/actions/runs/10942995090/job/30381326503?pr=854

## Environment
* OS: Ubuntu 22.04
* Python: 3.11.10
* Github Runer: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

### BREAKING CHANGES

### CHANGES
* Replaces watchfiles with watchdog

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
