### PR TITLE
chore(deps): update dependency ai to v3.4.0

### DIFF
--- a/src/leapfrogai_ui/package-lock.json
+++ b/src/leapfrogai_ui/package-lock.json
@@ -13,7 +13,7 @@
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.4",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
-        "ai": "^3.3.33",
+        "ai": "^3.4.0",
         "carbon-pictograms-svelte": "^12.11.0",
         "concurrently": "^8.2.2",
         "dompurify": "^3.1.6",
@@ -134,12 +134,12 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "0.0.55",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-0.0.55.tgz",
-      "integrity": "sha512-9fUUEEEoH01M6ZhvyZ/2v0DI6tiYnSldBg6RaKoy+qx2tSeKvOpFNZhT/iOvQ7oqAyyp0Ocg5Rj7L/jcLXSMxw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-0.0.59.tgz",
+      "integrity": "sha512-1WbgO3J2/OoheMuNMxy5itJ3NVqOpqpAQxFNp7AoXgnDv4wDF4kTif61rTlKh7dCPvBHj2HXLmob+TrVFaWhYw==",
       "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.18",
-        "@ai-sdk/ui-utils": "0.0.41",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/ui-utils": "0.0.44",
         "swr": "2.2.5"
       },
       "engines": {
@@ -158,13 +158,58 @@
         }
       }
     },
-    "node_modules/@ai-sdk/solid": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.44.tgz",
-      "integrity": "sha512-3kMhxalepc78jWr2Qg1BAHbY04JKYxp8wRu3TACrRUdokxzwD5sbZYtTb7vu9tw2wx78rfu0DH44CESFWpSfZg==",
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
+      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
       "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.18",
-        "@ai-sdk/ui-utils": "0.0.41"
+        "@ai-sdk/provider": "0.0.23",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
+      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "json-schema": "0.4.0",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.23.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/solid": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.47.tgz",
+      "integrity": "sha512-lVMxIxtuNqoo/TObSFGflEP2dUeJv7bfPQbS4jHTZGBNlyhgBRY2Xc19yNjA3QKRfvQNDVoQusqxn+18MiHJJQ==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/ui-utils": "0.0.44"
       },
       "engines": {
         "node": ">=18"
@@ -174,6 +219,51 @@
       },
       "peerDependenciesMeta": {
         "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/solid/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
+      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/solid/node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
+      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "json-schema": "0.4.0",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.23.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -223,12 +313,12 @@
       }
     },
     "node_modules/@ai-sdk/vue": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-0.0.46.tgz",
-      "integrity": "sha512-H366ydskPbZP8uRs4sm3SAi97P3JVTRI5Q8xYTI6uTaY4UFBA6aOWdDxniYZNa67ebemfe11m7ksX4wHW6Wl8g==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-0.0.51.tgz",
+      "integrity": "sha512-6RjuuRGf749EjnsfbETJpF0fmq6a1lF6qUUUnd/Q1Ojf0tX8fI4qwvNykbECZHWuIj42EqZ3HDuNNR9c8oG4rA==",
       "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.18",
-        "@ai-sdk/ui-utils": "0.0.41",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/ui-utils": "0.0.44",
         "swrv": "1.0.4"
       },
       "engines": {
@@ -239,6 +329,51 @@
       },
       "peerDependenciesMeta": {
         "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
+      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
+      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "json-schema": "0.4.0",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.23.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -2610,103 +2745,103 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.4.tgz",
-      "integrity": "sha512-oNwn+BAt3n9dK9uAYvI+XGlutwuTq/wfj4xCBaZCqwwVIGtD7D6ViihEbyYZrDHIHTDE3Q6oL3/hqmAyFEy9DQ==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.8.tgz",
+      "integrity": "sha512-Uzlxp91EPjfbpeO5KtC0KnXPkuTfGsNDeaKQJxQN718uz+RqDYarEf7UhQJGK+ZYloD2taUbHTI2J4WrUaZQNA==",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.4",
+        "@vue/shared": "3.5.8",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.4.tgz",
-      "integrity": "sha512-yP9RRs4BDLOLfldn6ah+AGCNovGjMbL9uHvhDHf5wan4dAHLnFGOkqtfE7PPe4HTXIqE7l/NILdYw53bo1C8jw==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.8.tgz",
+      "integrity": "sha512-GUNHWvoDSbSa5ZSHT9SnV5WkStWfzJwwTd6NMGzilOE/HM5j+9EB9zGXdtu/fCNEmctBqMs6C9SvVPpVPuk1Eg==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-core": "3.5.4",
-        "@vue/shared": "3.5.4"
+        "@vue/compiler-core": "3.5.8",
+        "@vue/shared": "3.5.8"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.4.tgz",
-      "integrity": "sha512-P+yiPhL+NYH7m0ZgCq7AQR2q7OIE+mpAEgtkqEeH9oHSdIRvUO+4X6MPvblJIWcoe4YC5a2Gdf/RsoyP8FFiPQ==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.8.tgz",
+      "integrity": "sha512-taYpngQtSysrvO9GULaOSwcG5q821zCoIQBtQQSx7Uf7DxpR6CIHR90toPr9QfDD2mqHQPCSgoWBvJu0yV9zjg==",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.4",
-        "@vue/compiler-dom": "3.5.4",
-        "@vue/compiler-ssr": "3.5.4",
-        "@vue/shared": "3.5.4",
+        "@vue/compiler-core": "3.5.8",
+        "@vue/compiler-dom": "3.5.8",
+        "@vue/compiler-ssr": "3.5.8",
+        "@vue/shared": "3.5.8",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.11",
-        "postcss": "^8.4.44",
+        "postcss": "^8.4.47",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.4.tgz",
-      "integrity": "sha512-acESdTXsxPnYr2C4Blv0ggx5zIFMgOzZmYU2UgvIff9POdRGbRNBHRyzHAnizcItvpgerSKQbllUc9USp3V7eg==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.8.tgz",
+      "integrity": "sha512-W96PtryNsNG9u0ZnN5Q5j27Z/feGrFV6zy9q5tzJVyJaLiwYxvC0ek4IXClZygyhjm+XKM7WD9pdKi/wIRVC/Q==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.5.4",
-        "@vue/shared": "3.5.4"
+        "@vue/compiler-dom": "3.5.8",
+        "@vue/shared": "3.5.8"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.4.tgz",
-      "integrity": "sha512-HKKbEuP7tYSGCq4e4nK6ZW6l5hyG66OUetefBp4budUyjvAYsnQDf+bgFzg2RAgnH0CInyqXwD9y47jwJEHrQw==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.8.tgz",
+      "integrity": "sha512-mlgUyFHLCUZcAYkqvzYnlBRCh0t5ZQfLYit7nukn1GR96gc48Bp4B7OIcSfVSvlG1k3BPfD+p22gi1t2n9tsXg==",
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.5.4"
+        "@vue/shared": "3.5.8"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.4.tgz",
-      "integrity": "sha512-f3ek2sTA0AFu0n+w+kCtz567Euqqa3eHewvo4klwS7mWfSj/A+UmYTwsnUFo35KeyAFY60JgrCGvEBsu1n/3LA==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.8.tgz",
+      "integrity": "sha512-fJuPelh64agZ8vKkZgp5iCkPaEqFJsYzxLk9vSC0X3G8ppknclNDr61gDc45yBGTaN5Xqc1qZWU3/NoaBMHcjQ==",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.5.4",
-        "@vue/shared": "3.5.4"
+        "@vue/reactivity": "3.5.8",
+        "@vue/shared": "3.5.8"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.4.tgz",
-      "integrity": "sha512-ofyc0w6rbD5KtjhP1i9hGOKdxGpvmuB1jprP7Djlj0X7R5J/oLwuNuE98GJ8WW31Hu2VxQHtk/LYTAlW8xrJdw==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.8.tgz",
+      "integrity": "sha512-DpAUz+PKjTZPUOB6zJgkxVI3GuYc2iWZiNeeHQUw53kdrparSTG6HeXUrYDjaam8dVsCdvQxDz6ZWxnyjccUjQ==",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.5.4",
-        "@vue/runtime-core": "3.5.4",
-        "@vue/shared": "3.5.4",
+        "@vue/reactivity": "3.5.8",
+        "@vue/runtime-core": "3.5.8",
+        "@vue/shared": "3.5.8",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.4.tgz",
-      "integrity": "sha512-FbjV6DJLgKRetMYFBA1UXCroCiED/Ckr53/ba9wivyd7D/Xw9fpo0T6zXzCnxQwyvkyrL7y6plgYhWhNjGxY5g==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.8.tgz",
+      "integrity": "sha512-7AmC9/mEeV9mmXNVyUIm1a1AjUhyeeGNbkLh39J00E7iPeGks8OGRB5blJiMmvqSh8SkaS7jkLWSpXtxUCeagA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.4",
-        "@vue/shared": "3.5.4"
+        "@vue/compiler-ssr": "3.5.8",
+        "@vue/shared": "3.5.8"
       },
       "peerDependencies": {
-        "vue": "3.5.4"
+        "vue": "3.5.8"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.4.tgz",
-      "integrity": "sha512-L2MCDD8l7yC62Te5UUyPVpmexhL9ipVnYRw9CsWfm/BGRL5FwDX4a25bcJ/OJSD3+Hx+k/a8LDKcG2AFdJV3BA==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.8.tgz",
+      "integrity": "sha512-mJleSWbAGySd2RJdX1RBtcrUBX6snyOc0qHpgk3lGi4l9/P/3ny3ELqFWqYdkXIwwNN/kdm8nD9ky8o6l/Lx2A==",
       "peer": true
     },
     "node_modules/@yr/monotone-cubic-spline": {
@@ -2778,17 +2913,17 @@
       }
     },
     "node_modules/ai": {
-      "version": "3.3.33",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-3.3.33.tgz",
-      "integrity": "sha512-qyYMebaySFF5jnaBfsxXcbjJtAmM3c9VP9r8RgBSGap7K+X/KrdFw1zJ3zad81MbGF6uG2tdNn/kw4k/muxX5w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-3.4.0.tgz",
+      "integrity": "sha512-79MZD3zoljLBf7Jtmd39bhDA3W7WPsozIi99sLrZlgxzh3JBX1XtCxHwrUYHQtAxl21BGzHmXpgNfLiQjdTAfA==",
       "dependencies": {
         "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.18",
-        "@ai-sdk/react": "0.0.55",
-        "@ai-sdk/solid": "0.0.44",
-        "@ai-sdk/svelte": "0.0.46",
-        "@ai-sdk/ui-utils": "0.0.41",
-        "@ai-sdk/vue": "0.0.46",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/react": "0.0.59",
+        "@ai-sdk/solid": "0.0.47",
+        "@ai-sdk/svelte": "0.0.49",
+        "@ai-sdk/ui-utils": "0.0.44",
+        "@ai-sdk/vue": "0.0.51",
         "@opentelemetry/api": "1.9.0",
         "eventsource-parser": "1.1.2",
         "json-schema": "0.4.0",
@@ -2820,6 +2955,72 @@
         "svelte": {
           "optional": true
         },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
+      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/svelte": {
+      "version": "0.0.49",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.49.tgz",
+      "integrity": "sha512-gV0MhaWxkatjf7uJrCAHO3bWrihokNUwGhuMCgyG+y53lwJKAYhR0zCoDRM2HnTJ89fdnx/PVe3R9fOWEVY5qA==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/ui-utils": "0.0.44",
+        "sswr": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
+      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.23",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "json-schema": "0.4.0",
+        "secure-json-parse": "2.7.0",
+        "zod-to-json-schema": "3.23.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
         "zod": {
           "optional": true
         }
@@ -6300,9 +6501,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6365,9 +6566,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.45",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6384,8 +6585,8 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -7306,9 +7507,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8878,16 +9079,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.4.tgz",
-      "integrity": "sha512-3yAj2gkmiY+i7+22A1PWM+kjOVXjU74UPINcTiN7grIVPyFFI0lpGwHlV/4xydDmobaBn7/xmi+YG8HeSlCTcg==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.8.tgz",
+      "integrity": "sha512-hvuvuCy51nP/1fSRvrrIqTLSvrSyz2Pq+KQ8S8SXCxTWVE0nMaOnSDnSOxV1eYmGfvK7mqiwvd1C59CEEz7dAQ==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.5.4",
-        "@vue/compiler-sfc": "3.5.4",
-        "@vue/runtime-dom": "3.5.4",
-        "@vue/server-renderer": "3.5.4",
-        "@vue/shared": "3.5.4"
+        "@vue/compiler-dom": "3.5.8",
+        "@vue/compiler-sfc": "3.5.8",
+        "@vue/runtime-dom": "3.5.8",
+        "@vue/server-renderer": "3.5.8",
+        "@vue/shared": "3.5.8"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/src/leapfrogai_ui/package.json
+++ b/src/leapfrogai_ui/package.json
@@ -77,7 +77,7 @@
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.4",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
-    "ai": "^3.3.33",
+    "ai": "^3.4.0",
     "carbon-pictograms-svelte": "^12.11.0",
     "concurrently": "^8.2.2",
     "dompurify": "^3.1.6",


### PR DESCRIPTION
## Description
Bumps UI's AI dependency to v3.4.0. Renovate #1064 attempted to do this but only updated the lock file, and not the package.json


- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
