### PR TITLE
chore(ui): streaming text response deprecated

### DIFF
--- a/src/leapfrogai_ui/package-lock.json
+++ b/src/leapfrogai_ui/package-lock.json
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@playwright/test": "^1.47.0",
+        "@playwright/test": "^1.47.2",
         "@sveltejs/adapter-auto": "^3.2.4",
         "@sveltejs/adapter-node": "^5.2.2",
         "@sveltejs/kit": "^2.5.26",
@@ -1421,37 +1421,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
-      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+      "integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.47.0"
+        "playwright": "1.47.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
-      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.47.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/@polka/url": {
@@ -6371,18 +6352,6 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
-      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {

--- a/src/leapfrogai_ui/package-lock.json
+++ b/src/leapfrogai_ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@ai-sdk/openai": "^0.0.61",
-        "@ai-sdk/svelte": "^0.0.46",
+        "@ai-sdk/svelte": "^0.0.49",
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.4",
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
@@ -101,29 +101,6 @@
         "zod": "^3.0.0"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
-      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ai-sdk/provider": {
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.23.tgz",
@@ -136,9 +113,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.18.tgz",
-      "integrity": "sha512-9u/XE/dB1gsIGcxiC5JfGOLzUz+EKRXt66T8KYWwDg4x8d02P+fI/EPOgkf+T4oLBrcQgvs4GPXPKoXGPJxBbg==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
+      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
       "dependencies": {
         "@ai-sdk/provider": "0.0.23",
         "eventsource-parser": "1.1.2",
@@ -182,51 +159,6 @@
         }
       }
     },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
-      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
-      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.19",
-        "json-schema": "0.4.0",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ai-sdk/solid": {
       "version": "0.0.47",
       "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.47.tgz",
@@ -247,58 +179,13 @@
         }
       }
     },
-    "node_modules/@ai-sdk/solid/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
-      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/solid/node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
-      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.19",
-        "json-schema": "0.4.0",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ai-sdk/svelte": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.46.tgz",
-      "integrity": "sha512-cokqS91vQkpqiRgf8xKwOONFb/RwkIbRg9jYVRb+z5NR9OsWXKMEfoCAf8+VgURfVbp8nqA+ddRXvtgYCwqQjQ==",
+      "version": "0.0.49",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.49.tgz",
+      "integrity": "sha512-gV0MhaWxkatjf7uJrCAHO3bWrihokNUwGhuMCgyG+y53lwJKAYhR0zCoDRM2HnTJ89fdnx/PVe3R9fOWEVY5qA==",
       "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.18",
-        "@ai-sdk/ui-utils": "0.0.41",
+        "@ai-sdk/provider-utils": "1.0.19",
+        "@ai-sdk/ui-utils": "0.0.44",
         "sswr": "2.1.0"
       },
       "engines": {
@@ -314,12 +201,12 @@
       }
     },
     "node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.41.tgz",
-      "integrity": "sha512-I0trJKWxVG8hXeG0MvKqLG54fZjdeGjXvcVZocaSnWMBhl9lpTQxrqAR6ZsQMFDXs5DbvXoKtQs488qu2Bzaiw==",
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
+      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
       "dependencies": {
         "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.18",
+        "@ai-sdk/provider-utils": "1.0.19",
         "json-schema": "0.4.0",
         "secure-json-parse": "2.7.0",
         "zod-to-json-schema": "3.23.2"
@@ -353,51 +240,6 @@
       },
       "peerDependenciesMeta": {
         "vue": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
-      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/vue/node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
-      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.19",
-        "json-schema": "0.4.0",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
           "optional": true
         }
       }
@@ -2998,72 +2840,6 @@
         "svelte": {
           "optional": true
         },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.19.tgz",
-      "integrity": "sha512-p02Fq5Mnc8T6nwRBN1Iaou8YXvN1sDS6hbmJaD5UaRbXjizbh+8rpFS/o7jqAHTwf3uHCDitP3pnODyHdc/CDQ==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "eventsource-parser": "1.1.2",
-        "nanoid": "3.3.6",
-        "secure-json-parse": "2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/svelte": {
-      "version": "0.0.49",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.49.tgz",
-      "integrity": "sha512-gV0MhaWxkatjf7uJrCAHO3bWrihokNUwGhuMCgyG+y53lwJKAYhR0zCoDRM2HnTJ89fdnx/PVe3R9fOWEVY5qA==",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "1.0.19",
-        "@ai-sdk/ui-utils": "0.0.44",
-        "sswr": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "svelte": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "svelte": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/ui-utils": {
-      "version": "0.0.44",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.44.tgz",
-      "integrity": "sha512-0qiyun/n5zqJzQs/WfQT86dZE5DiDhSHJc7b7ZGLYvNMztHkRQmak2zUCZP4IyGVZEicyEPQK6NEEpBgkmd3Dg==",
-      "dependencies": {
-        "@ai-sdk/provider": "0.0.23",
-        "@ai-sdk/provider-utils": "1.0.19",
-        "json-schema": "0.4.0",
-        "secure-json-parse": "2.7.0",
-        "zod-to-json-schema": "3.23.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
         "zod": {
           "optional": true
         }

--- a/src/leapfrogai_ui/package.json
+++ b/src/leapfrogai_ui/package.json
@@ -73,7 +73,7 @@
   "type": "module",
   "dependencies": {
     "@ai-sdk/openai": "^0.0.61",
-    "@ai-sdk/svelte": "^0.0.46",
+    "@ai-sdk/svelte": "^0.0.49",
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.4",
     "@sveltejs/vite-plugin-svelte": "^3.1.2",

--- a/src/leapfrogai_ui/package.json
+++ b/src/leapfrogai_ui/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
-    "@playwright/test": "^1.47.0",
+    "@playwright/test": "^1.47.2",
     "@sveltejs/adapter-auto": "^3.2.4",
     "@sveltejs/adapter-node": "^5.2.2",
     "@sveltejs/kit": "^2.5.26",

--- a/src/leapfrogai_ui/src/lib/mocks/chat-mocks.ts
+++ b/src/leapfrogai_ui/src/lib/mocks/chat-mocks.ts
@@ -3,7 +3,7 @@ import { server } from '../../../vitest-setup';
 import { getFakeOpenAIMessage } from '$testUtils/fakeData';
 import type { LFMessage, NewMessageInput } from '$lib/types/messages';
 import type { LFAssistant } from '$lib/types/assistants';
-import { createStreamDataTransformer, StreamingTextResponse } from 'ai';
+import { createStreamDataTransformer } from 'ai';
 import type { LFThread } from '$lib/types/threads';
 import { AUDIO_FILE_SIZE_ERROR_TEXT } from '$constants';
 
@@ -22,7 +22,9 @@ const returnStreamResponse = (responseMsg: string[]) => {
       controller.close();
     }
   });
-  return new StreamingTextResponse(stream.pipeThrough(createStreamDataTransformer()));
+  return new HttpResponse(stream.pipeThrough(createStreamDataTransformer()), {
+    headers: { 'Content-Type': 'text/event-stream' }
+  });
 };
 export const mockChatCompletion = (options: MockChatCompletionOptions = {}) => {
   const { delayTime = 0, responseMsg = ['Fake', 'AI', 'Response'] } = options;

--- a/src/leapfrogai_ui/src/routes/api/chat/+server.ts
+++ b/src/leapfrogai_ui/src/routes/api/chat/+server.ts
@@ -1,5 +1,5 @@
 import type { RequestHandler } from './$types';
-import { StreamingTextResponse, streamText } from 'ai';
+import { streamText } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { env } from '$env/dynamic/private';
 import { error } from '@sveltejs/kit';
@@ -43,5 +43,5 @@ export const POST: RequestHandler = async ({ request, locals: { session } }) => 
     system: env.DEFAULT_SYSTEM_PROMPT
   });
 
-  return new StreamingTextResponse(result.toAIStream());
+  return result.toDataStreamResponse();
 };


### PR DESCRIPTION
## Description
Removes StreamingTextResponse usage from ai package which was depracted. Also bumps @playwright/test to 1.47.2 due to an issue with running playwright tests in headed mode. This was not working properly after renovate bumped to 1.47.0.

Closes #1095 

## Checklist before merging

- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
