### PR TITLE
fix(api): make model field optional in ModifyAssistantRequest type

### DIFF
--- a/src/leapfrogai_api/typedef/assistants/assistant_types.py
+++ b/src/leapfrogai_api/typedef/assistants/assistant_types.py
@@ -27,14 +27,13 @@ from leapfrogai_api.utils.validate_tools import (
 logger = logging.getLogger(__name__)
 
 
-class CreateAssistantRequest(BaseModel):
-    """Request object for creating an assistant."""
+class BaseAssistantRequest(BaseModel):
+    """
+    Base Request object for creating or modifying an assistant.
+    This class should not be used directly. Use CreateAssistantRequest or ModifyAssistantRequest instead.
+    Model field is required for CreateAssistantRequest, but optional for ModifyAssistantRequest.
+    """
 
-    model: str = Field(
-        default="llama-cpp-python",
-        examples=["llama-cpp-python"],
-        description="The model to be used by the assistant. Default is 'llama-cpp-python'.",
-    )
     name: str | None = Field(
         default=None,
         examples=["Froggy Assistant"],
@@ -202,11 +201,24 @@ class CreateAssistantRequest(BaseModel):
                 self.tool_resources.file_search.vector_stores = None
 
 
-class ModifyAssistantRequest(CreateAssistantRequest):
+class CreateAssistantRequest(BaseAssistantRequest):
+    """Request object for creating an assistant."""
+
+    model: str = Field(
+        default="llama-cpp-python",
+        examples=["llama-cpp-python"],
+        description="The model to be used by the assistant. Default is 'llama-cpp-python'.",
+    )
+
+
+class ModifyAssistantRequest(BaseAssistantRequest):
     """Request object for modifying an assistant."""
 
-    # Inherits all fields from CreateAssistantRequest
-    # All fields are optional for modification
+    model: str | None = Field(
+        default=None,
+        examples=["llama-cpp-python", None],
+        description="The model to be used by the assistant. Default is 'llama-cpp-python'.",
+    )
 
 
 class ListAssistantsResponse(BaseModel):

--- a/tests/conformance/test_conformance_assistants.py
+++ b/tests/conformance/test_conformance_assistants.py
@@ -1,7 +1,7 @@
 import pytest
 from openai.types.beta.assistant import Assistant
 
-from ..utils.client import client_config_factory
+from tests.utils.client import client_config_factory
 
 
 @pytest.mark.parametrize("client_name", ["openai", "leapfrogai"])
@@ -20,3 +20,34 @@ def test_assistant(client_name):
     )
 
     assert isinstance(assistant, Assistant)
+
+    client.beta.assistants.delete(assistant.id)
+
+
+@pytest.mark.parametrize("client_name", ["openai", "leapfrogai"])
+def test_modify_assistant(client_name):
+    config = client_config_factory(client_name)
+    client = config.client
+
+    vector_store = client.beta.vector_stores.create(name="Test data")
+
+    assistant = client.beta.assistants.create(
+        name="Test Assistant",
+        instructions="You must provide a response based on the attached files.",
+        model=config.model,
+        tools=[{"type": "file_search"}],
+        tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
+        metadata={"Test": "Testing."},
+    )
+
+    modified_assistant = client.beta.assistants.update(
+        assistant.id,
+        name="Modified Assistant",
+        metadata={"Test 2": "This is the test."},
+    )
+
+    assert modified_assistant.name == "Modified Assistant"
+    assert modified_assistant.id == assistant.id
+    assert modified_assistant.model == assistant.model
+
+    client.beta.assistants.delete(modified_assistant.id)

--- a/tests/utils/client.py
+++ b/tests/utils/client.py
@@ -20,7 +20,7 @@ def leapfrogai_client():
         base_url=os.getenv(
             "LEAPFROGAI_API_URL", "https://leapfrogai-api.uds.dev/openai/v1"
         ),
-        api_key=os.getenv("SUPABASE_USER_JWT"),
+        api_key=os.getenv("LEAPFROGAI_API_KEY") or os.getenv("SUPABASE_USER_JWT"),
     )
 
 


### PR DESCRIPTION
## Description

Fixes issue where modifying certain fields on an assistant can also overwrite the intended model for that assistant.

### BREAKING CHANGES

None

### CHANGES

## Related Issue

Fixes #1156 

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
