### PR TITLE
fix(ui): allow large transcribe and translate responses

### DIFF
--- a/src/leapfrogai_ui/src/lib/components/FileChatActions.svelte
+++ b/src/leapfrogai_ui/src/lib/components/FileChatActions.svelte
@@ -132,7 +132,8 @@
           role: 'assistant',
           metadata: {
             wasTranscriptionOrTranslation: 'true'
-          }
+          },
+          lengthOverride: true
         });
       } catch {
         await handleGeneralError(toastError);


### PR DESCRIPTION
## Description
Allows large transcribe and translate messages to be saved to the DB (we should only prevent large user messages)

## Checklist before merging

- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
