### PR TITLE
fix: nightly snapshots repository typo

### DIFF
--- a/.github/workflows/nightly-snapshot-release.yaml
+++ b/.github/workflows/nightly-snapshot-release.yaml
@@ -170,6 +170,7 @@ jobs:
         env:
           ANON_KEY: ${{ steps.generate_secrets.outputs.ANON_KEY }}
           SERVICE_KEY: ${{ steps.generate_secrets.outputs.SERVICE_KEY }}
+          LEAPFROGAI_MODEL: llama-cpp-python
         run: |
           python -m pytest -vvv -s ./tests/e2e
 

--- a/.github/workflows/nightly-snapshot-release.yaml
+++ b/.github/workflows/nightly-snapshot-release.yaml
@@ -24,7 +24,7 @@ defaults:
 
 env:
   SNAPSHOT_VERSION: snapshot-latest
-  SNAPSHOT_SUB_REPOSITORY: /uds/snapshots
+  SNAPSHOT_SUB_REPOSITORY: /uds/snapshots/
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

There is a typo where the repository is missing a `/` at the end of `/uds/snapshots`, causing the packages to be published to the incorrect namespace.

As a correction to this action, all packages published to the `/uds/snapshots[PACKAGE_NAME]` namespace should be deleted upon the merging of this PR (e.g., [packages/uds/snapshotssupabase](https://github.com/orgs/defenseunicorns/packages/container/package/packages%2Fuds%2Fsnapshotsleapfrogai%2Fsupabase))

### BREAKING CHANGES

### CHANGES

- fix for typo that was introduced when variabilizing the namespace for snapshot releases

## Related Issue

N/A

## Checklist before merging

- [X] Tests, documentation, ADR added or updated as needed
- [X] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
