### PR TITLE
fix(whisper): failing gpu pod due to mangled env variable

### DIFF
--- a/packages/whisper/Dockerfile
+++ b/packages/whisper/Dockerfile
@@ -37,8 +37,8 @@ COPY --from=builder /leapfrogai/.venv/ /leapfrogai/.venv/
 
 # set the path to the cuda 11.8 dependencies
 ENV LD_LIBRARY_PATH \
-    /leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cublas/lib:\
-    /leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cudnn/lib
+/leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cublas/lib:\
+/leapfrogai/.venv/lib64/python3.11/site-packages/nvidia/cudnn/lib
 
 COPY packages/whisper/main.py .
 


### PR DESCRIPTION
## Description

* Removes newlines that were causing the creation of an invalid environment variable entry.
* Resolves issue with failing gpu pod being unable to find the `libcudnn_ops_infer.so` file.

![Screenshot 2024-10-02 at 9 09 16 AM](https://github.com/user-attachments/assets/77a2c0e6-73b6-4099-b353-d027c05ed043)

## Checklist before merging

- [x] Tests, documentation, ADR added or updated as needed
- [x] Followed the [Contributor Guide Steps](https://github.com/defenseunicorns/leapfrogai/blob/main/.github/CONTRIBUTING.md)
